### PR TITLE
200% default minimum liquidity ratio

### DIFF
--- a/tomls/core.toml
+++ b/tomls/core.toml
@@ -6,7 +6,17 @@ defaultValue = "synthetix:3.0.0-alpha.7"
 [setting.salt]
 defaultValue = "snx"
 
+[setting.minimum_liquidity_ratio]
+defaultValue = "200000000000000000000"
+
 [provision.system]
 source = "<%= settings.snx_package %>"
 options.owner = "<%= settings.owner %>"
 options.salt = "<%= settings.salt %>"
+
+[invoke.setMinimumLiquidityRatio]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setMinLiquidityRatio"
+args = ["<%= settings.minimum_liquidity_ratio %>"]
+depends = ["provision.system"]


### PR DESCRIPTION
Seeing `Error: invalid BigNumber string`

When trying to use parseEther helper:
```
[setting.minimum_liquidity_ratio]
defaultValue = "<%= parseEther('200') %>"
```