### PR TITLE
pythPriceVerificationAddress should be set on network-level config

### DIFF
--- a/omnibus-optimism-goerli.toml
+++ b/omnibus-optimism-goerli.toml
@@ -81,7 +81,7 @@ target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxCollateralAmount"
 args = [
-  "0", 
+  "0",
   "<%= MaxUint256 %>"
 ]
 depends = ["provision.perpsFactory"]
@@ -91,7 +91,7 @@ target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxCollateralAmount"
 args = [
-  "<%= extras.synth_eth_market_id %>", 
+  "<%= extras.synth_eth_market_id %>",
   "<%= MaxUint256 %>"
 ]
 depends = ["invoke.createEthSynth", "provision.perpsFactory"]
@@ -223,8 +223,8 @@ fromCall.func = "getMarketOwner"
 fromCall.args = ["<%= extras.synth_eth_market_id %>"]
 func = "setCustomTransactorFees"
 args = [
-  "<%= extras.synth_eth_market_id %>", 
-  "<%= imports.perpsFactory.contracts.PerpsMarketProxy.address %>", 
+  "<%= extras.synth_eth_market_id %>",
+  "<%= imports.perpsFactory.contracts.PerpsMarketProxy.address %>",
   "<%= parseEther('0.0001') %>"
 ]
 depends=["provision.perpsFactory", "invoke.createEthSynth"]
@@ -235,8 +235,8 @@ fromCall.func = "getMarketOwner"
 fromCall.args = ["<%= extras.synth_btc_market_id %>"]
 func = "setCustomTransactorFees"
 args = [
-  "<%= extras.synth_btc_market_id %>", 
-  "<%= imports.perpsFactory.contracts.PerpsMarketProxy.address %>", 
+  "<%= extras.synth_btc_market_id %>",
+  "<%= imports.perpsFactory.contracts.PerpsMarketProxy.address %>",
   "<%= parseEther('0.0001') %>"
 ]
 depends=["provision.perpsFactory", "invoke.createBtcSynth"]
@@ -250,6 +250,9 @@ defaultValue = "0xca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57
 
 [setting.pythBtcFeedId]
 defaultValue = "0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b"
+
+[setting.pythPriceVerificationAddress]
+defaultValue = "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C"
 
 [setting.priceWindowDuration]
 defaultValue = "180"

--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -87,6 +87,9 @@ defaultValue = "https://api.synthetix.io/pyth-mainnet/api/get_vaa_ccip?data={dat
 [setting.pythEthFeedId]
 defaultValue = "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
 
+[setting.pythPriceVerificationAddress]
+defaultValue = "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C"
+
 [invoke.setScPoolConfig]
 target = ["system.CoreProxy"]
 fromCall.func = "getPoolOwner"

--- a/tomls/markets/common/settlement-strategies/btc/pyth.toml
+++ b/tomls/markets/common/settlement-strategies/btc/pyth.toml
@@ -8,7 +8,6 @@ defaultValue = "60"
 defaultValue = "600"
 
 [setting.pythPriceVerificationAddress]
-defaultValue = "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C"
 
 [setting.pythBtcFeedId]
 

--- a/tomls/markets/common/settlement-strategies/eth/pyth.toml
+++ b/tomls/markets/common/settlement-strategies/eth/pyth.toml
@@ -8,7 +8,6 @@ defaultValue = "60"
 defaultValue = "600"
 
 [setting.pythPriceVerificationAddress]
-defaultValue = "0xff1a0f4744e8582DF1aE09D5611b887B6a12925C"
 
 [setting.pythEthFeedId]
 


### PR DESCRIPTION
We were lucky till now as pyth verification address is same on `op goerli` and `op mainnet`.
But when adding `base mainnet` deployment I have found that this address is different for `base mainnet` and `base goerli`

See https://docs.pyth.network/documentation/pythnet-price-feeds/evm for context