### PR TITLE
dont configure WETH on optimism-mainnet

### DIFF
--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -6,7 +6,8 @@ include = [
     "tomls/core.toml",
     "tomls/permissions.toml",
     "tomls/collaterals/snx.toml",
-    "tomls/collaterals/weth.toml",
+		# eth collateral is not enabled/set up on v3
+    #"tomls/collaterals/weth.toml",
     "tomls/pools/spartan-council.toml",
     "tomls/pools/passive-snx.toml",
     "tomls/permit-all-transferCrossChain.toml",


### PR DESCRIPTION
we want it to remain disabled, so the best thing is to remove cannon management of this collateral type.