### PR TITLE
SIP-324 Passive SNX Pool - Goerli `staging` deployment

### DIFF
--- a/omnibus-goerli.toml
+++ b/omnibus-goerli.toml
@@ -6,13 +6,16 @@ include = [
     "tomls/core.toml",
     "tomls/permissions.toml",
     "tomls/collaterals/snx.toml",
-    "tomls/collaterals/weth.toml",
     "tomls/pools/spartan-council.toml",
     "tomls/pools/passive-snx.toml",
-    "tomls/permit-all-createPool.toml",
-    "tomls/permit-all-registerMarket.toml",
     "tomls/permit-all-transferCrossChain.toml",
 ]
+
+[setting.target_preset]
+defaultValue = "main"
+
+[setting.salt]
+defaultValue = "staging"
 
 [setting.snx_package]
 defaultValue = "synthetix:3.3.4"


### PR DESCRIPTION
1. goerli deployment is a mirror of `mainnet` deployment with goerli-specific configs only
2. after merging/deploying we will transfer ownership to the safe account and deploy in the same way we deploy mainnet.
3. we can only add things to it as a final test before deploying to mainnet.
4. if we want to have `dev` deployment we should use a separate deployment file like `omnibus-goerli-dev.toml`

NOTE: Simulate release for goerli is expected to fail with `Proxy InitialCoreProxy was modified` because of full redeployment from scratch (salt change)