### PR TITLE
Andromeda: Fix feed ids

### DIFF
--- a/tomls/omnibus-base-goerli-andromeda/perps/ltc.toml
+++ b/tomls/omnibus-base-goerli-andromeda/perps/ltc.toml
@@ -1,5 +1,5 @@
 [setting.pythLtcFeedId]
-defaultValue = "0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b"
+defaultValue = "0x997e0bf451cb36b4aea096e6b5c254d700922211dd933d9d17c467f0d6f34321"
 
 # Perps Configuration
 [setting.ltcPerpsMarketId]

--- a/tomls/omnibus-base-goerli-andromeda/perps/xrp.toml
+++ b/tomls/omnibus-base-goerli-andromeda/perps/xrp.toml
@@ -1,5 +1,5 @@
 [setting.pythXrpFeedId]
-defaultValue = "0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b"
+defaultValue = "0xbfaf7739cb6fe3e1c57a0ac08e1d931e9e6062d476fa57804e165ab572b5b621"
 
 # Perps Configuration
 [setting.xrpPerpsMarketId]


### PR DESCRIPTION
Feed ids for LTC and XRP were pointing at the BTC feed. Updating them base on the [Pyth](https://pyth.network/developers/price-feed-ids#pyth-evm-testnet) feed ids.