### PR TITLE
Update fUSDC collateral

### DIFF
--- a/e2e/fetch-deployments.js
+++ b/e2e/fetch-deployments.js
@@ -117,9 +117,10 @@ async function run() {
   function mintableToken(provisionStep) {
     const fakeCollateral =
       deployments?.state?.[`provision.${provisionStep}`]?.artifacts?.imports?.[provisionStep];
-    if (fakeCollateral) {
-      const [, ticker] = fakeCollateral.contracts.MintableToken.constructorArgs;
-      contracts[`FakeCollateral${ticker}`] = fakeCollateral.contracts.MintableToken;
+    const fakeCollateralOptions = deployments?.def?.provision?.[provisionStep]?.options;
+    if (fakeCollateral && fakeCollateralOptions) {
+      contracts[`FakeCollateral${fakeCollateralOptions.symbol}`] =
+        fakeCollateral.contracts.MintableToken;
     }
   }
   mintableToken('usdc_mock_collateral');

--- a/e2e/tasks/getCollateralConfig.js
+++ b/e2e/tasks/getCollateralConfig.js
@@ -4,7 +4,10 @@ const { getCollateralConfigurations } = require('./getCollateralConfigurations')
 
 async function getCollateralConfig(symbol) {
   const collateralConfigs = await getCollateralConfigurations();
-  const config = collateralConfigs.find((cfg) => cfg.symbol === symbol);
+  const config = collateralConfigs
+    .slice(0) // Create new array instance
+    .reverse() // If we redeploy with same symbol we want the get the latest one from the list
+    .find((cfg) => cfg.symbol === symbol);
   if (!config) {
     throw new Error(`Collateral config for "${symbol}" does not exist`);
   }

--- a/e2e/tasks/getCollateralConfiguration.js
+++ b/e2e/tasks/getCollateralConfiguration.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+const CoreProxyDeployment = require('../deployments/CoreProxy.json');
+
+async function getCollateralConfiguration(address) {
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+  const CoreProxy = new ethers.Contract(
+    CoreProxyDeployment.address,
+    CoreProxyDeployment.abi,
+    provider
+  );
+  const config = await CoreProxy.getCollateralConfiguration(address);
+  const contract = new ethers.Contract(
+    config.tokenAddress,
+    ['function symbol() view returns (string)'],
+    provider
+  );
+
+  const symbol = await contract.symbol();
+  const collateralConfig = {
+    symbol,
+    tokenAddress: config.tokenAddress,
+    depositingEnabled: config.depositingEnabled,
+    issuanceRatioD18: config.issuanceRatioD18,
+    liquidationRatioD18: config.liquidationRatioD18,
+    liquidationRewardD18: config.liquidationRewardD18,
+    oracleNodeId: config.oracleNodeId,
+    minDelegationD18: config.minDelegationD18,
+  };
+
+  return collateralConfig;
+}
+
+module.exports = {
+  getCollateralConfiguration,
+};
+
+if (require.main === module) {
+  require('../inspect');
+  const [address] = process.argv.slice(2);
+  getCollateralConfiguration(address).then(console.log);
+}

--- a/e2e/tests/omnibus-base-mainnet-andromeda.toml/Collateral_Limits.e2e.js
+++ b/e2e/tests/omnibus-base-mainnet-andromeda.toml/Collateral_Limits.e2e.js
@@ -4,7 +4,6 @@ require('../../inspect');
 
 const { getEthBalance } = require('../../tasks/getEthBalance');
 const { setEthBalance } = require('../../tasks/setEthBalance');
-const { getCollateralConfig } = require('../../tasks/getCollateralConfig');
 const { getCollateralBalance } = require('../../tasks/getCollateralBalance');
 const { isCollateralApproved } = require('../../tasks/isCollateralApproved');
 const { approveCollateral } = require('../../tasks/approveCollateral');
@@ -126,7 +125,7 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
       SYNTH_USDC_MAX_MARKET_COLLATERAL - newMarketCollateral < 1,
       'Less than 1 USDC left before reaching max collateral limit'
     );
-    await assert.rejects(async () => await wrapUsdc({ wallet, amount: 1 }));
+    await assert.rejects(async () => await wrapCollateral({ wallet, symbol: 'USDC', amount: 1 }));
   });
 
   it('should unwrap all the sUSDC back to USDC and reduce market collateral', async () => {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:base-sepolia": "cannon build omnibus-base-sepolia-andromeda.toml --dry-run --upgrade-from synthetix-omnibus:latest@andromeda --chain-id 84532 --provider-url https://sepolia.base.org | tee ./e2e/cannon-build.log",
     "start:andromeda": "cannon run synthetix-omnibus:latest@andromeda --chain-id 84531 --provider-url https://goerli.base.org",
     "start:base": "cannon run synthetix-omnibus:latest@andromeda --chain-id 8453 --provider-url https://mainnet.base.org",
-    "start:base-sepolia": "cannon run synthetix-omnibus:latest@andromeda --chain-id 84532 --provider-url https://sepolia.base.org",
+    "start:base-sepolia": "cannon build omnibus-base-sepolia-andromeda.toml --keep-alive --dry-run --port 8545 --upgrade-from synthetix-omnibus:latest@andromeda --chain-id 84532 --provider-url https://sepolia.base.org | tee ./e2e/cannon-build.log",
     "anvil:base": "anvil --chain-id 8453 --fork-url https://mainnet.base.org",
     "anvil:base-goerli": "anvil --chain-id 84531 --fork-url https://goerli.base.org",
     "anvil:base-sepolia": "anvil --chain-id 84532 --fork-url https://sepolia.base.org",

--- a/tomls/omnibus-base-sepolia-andromeda/spot/usdc.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/spot/usdc.toml
@@ -63,7 +63,7 @@ minDelegationD18 = "<%= parseEther('100') %>"
 depositingEnabled = false
 
 [provision.usdc_mock_collateral]
-source = "mintable-token:1.7"
+source = "mintable-token:1.8"
 options.name = "Fake USD Coin"
 options.symbol = "fUSDC"
 options.owner = "<%= settings.owner %>"


### PR DESCRIPTION
- switch to the newer version of mintable-token that supports owner
- fix `getCollateralConfig` to use the latest configured collateral (as we deploy another one with same symbol now)
- fix contracts generator to use mintable token options because new version of mintable-token is incompatible (this must be fixed in `mintable-token` package to remain compatible though, but it is not a blocker for this deployment)
- minor test fixes to better align mainnet and sepolia

Owner is as configured on mintable token now

<img width="565" alt="image" src="https://github.com/Synthetixio/synthetix-deployments/assets/28145325/2c581ef0-b70d-4b3b-9d80-154dc6423640">


NOTE: we now have two fUSDC collaterals and only the last one is the correct one, first one is not correct

<img width="865" alt="image" src="https://github.com/Synthetixio/synthetix-deployments/assets/28145325/d4e23c3a-9b2a-496b-8068-1785ccc7ae6d">
