### PR TITLE
Report gas usage in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,13 +249,24 @@ jobs:
           path: "./e2e/deployments"
 
       - run:
+          name: "Debug logs"
+          background: true
+          command: |
+            touch "./debug-<< parameters.chain-id >>-<< parameters.preset >>.log"
+            tail -f "./debug-<< parameters.chain-id >>-<< parameters.preset >>.log"
+
+      - run:
           name: "Run tests"
           environment:
             DEBUG: "e2e:*"
+            DEBUG_TARGET: "./debug-<< parameters.chain-id >>-<< parameters.preset >>.log"
             GAS_REPORT: "./gas-<< parameters.chain-id >>-<< parameters.preset >>.csv"
           command: |
             TEST_FILES=$(circleci tests glob 'e2e/tests/<< parameters.toml >>/*.e2e.js')
             echo "$TEST_FILES" | circleci tests run --verbose --split-by=timings --command="xargs yarn mocha --no-bail --exit"
+
+      - store_artifacts:
+          path: "./debug-<< parameters.chain-id >>-<< parameters.preset >>.log"
 
       - store_artifacts:
           path: "./gas-<< parameters.chain-id >>-<< parameters.preset >>.csv"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,9 @@ jobs:
         type: integer
       provider-url:
         type: string
-      upgrade-from:
+      package:
+        type: string
+      preset:
         type: string
     docker:
       - image: cimg/node:<< pipeline.parameters.node-version >>
@@ -191,14 +193,14 @@ jobs:
       - yarn-install
 
       - run:
-          name: "Build new package upgrading from << parameters.upgrade-from >> and keep RPC running"
+          name: "Build new package upgrading from << parameters.package >>@<< parameters.preset >> and keep RPC running"
           background: true
           command: |
             yarn cannon build << parameters.toml >> \
               --keep-alive \
               --port 8545 \
               --dry-run \
-              --upgrade-from << parameters.upgrade-from >> \
+              --upgrade-from << parameters.package >>@<< parameters.preset >> \
               --chain-id << parameters.chain-id >> \
               --provider-url << parameters.provider-url >> \
                 | tee ./cannon-build.log
@@ -250,13 +252,13 @@ jobs:
           name: "Run tests"
           environment:
             DEBUG: "e2e:*"
-            GAS_REPORT: "./gas.csv"
+            GAS_REPORT: "./gas-<< parameters.chain-id >>-<< parameters.preset >>.csv"
           command: |
             TEST_FILES=$(circleci tests glob 'e2e/tests/<< parameters.toml >>/*.e2e.js')
             echo "$TEST_FILES" | circleci tests run --verbose --split-by=timings --command="xargs yarn mocha --no-bail --exit"
 
       - store_artifacts:
-          path: "./gas.csv"
+          path: "./gas-<< parameters.chain-id >>-<< parameters.preset >>.csv"
 
   fork-test-new:
     parameters:
@@ -465,63 +467,72 @@ workflows:
       - fork-test:
           name: base-sepolia-andromeda
           toml: omnibus-base-sepolia-andromeda.toml
-          upgrade-from: "synthetix-omnibus:latest@andromeda"
+          package: "synthetix-omnibus:latest"
+          preset: "andromeda"
           chain-id: 84532
           provider-url: https://sepolia.base.org
 
       - fork-test:
           name: base-goerli-andromeda
           toml: omnibus-base-goerli-andromeda.toml
-          upgrade-from: "synthetix-omnibus:latest@andromeda"
+          package: "synthetix-omnibus:latest"
+          preset: "andromeda"
           chain-id: 84531
           provider-url: https://goerli.base.org
 
       - fork-test:
           name: base-mainnet-andromeda
           toml: omnibus-base-mainnet-andromeda.toml
-          upgrade-from: "synthetix-omnibus:latest@andromeda"
+          package: "synthetix-omnibus:latest"
+          preset: "andromeda"
           chain-id: 8453
           provider-url: https://mainnet.base.org
 
       - fork-test:
           name: base-goerli
           toml: omnibus-base-goerli.toml
-          upgrade-from: "synthetix-omnibus:latest@main"
+          package: "synthetix-omnibus:latest"
+          preset: "main"
           chain-id: 84531
           provider-url: https://goerli.base.org
 
       - fork-test:
           name: goerli
           toml: omnibus-goerli.toml
-          upgrade-from: "synthetix-omnibus:latest@main"
+          package: "synthetix-omnibus:latest"
+          preset: "main"
           chain-id: 5
           provider-url: https://goerli.infura.io/v3/$INFURA_API_KEY
 
       - fork-test:
           name: mainnet
           toml: omnibus-mainnet.toml
-          upgrade-from: "synthetix-omnibus:latest@main"
+          package: "synthetix-omnibus:latest"
+          preset: "main"
           chain-id: 1
           provider-url: https://mainnet.infura.io/v3/$INFURA_API_KEY
 
       - fork-test:
           name: optimism-mainnet
           toml: omnibus-optimism-mainnet.toml
-          upgrade-from: "synthetix-omnibus:latest@main"
+          package: "synthetix-omnibus:latest"
+          preset: "main"
           chain-id: 10
           provider-url: https://optimism-mainnet.infura.io/v3/$INFURA_API_KEY
 
       - fork-test:
           name: sepolia
           toml: omnibus-sepolia.toml
-          upgrade-from: "synthetix-omnibus:latest@main"
+          package: "synthetix-omnibus:latest"
+          preset: "main"
           chain-id: 11155111
           provider-url: https://sepolia.infura.io/v3/$INFURA_API_KEY
 
       - fork-test:
           name: polygon-mumbai
           toml: omnibus-polygon-mumbai.toml
-          upgrade-from: "synthetix-omnibus:latest@main"
+          package: "synthetix-omnibus:latest"
+          preset: "main"
           chain-id: 80001
           provider-url: https://polygon-mumbai.infura.io/v3/$INFURA_API_KEY
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,9 +250,13 @@ jobs:
           name: "Run tests"
           environment:
             DEBUG: "e2e:*"
+            GAS_REPORT: "./gas.csv"
           command: |
             TEST_FILES=$(circleci tests glob 'e2e/tests/<< parameters.toml >>/*.e2e.js')
             echo "$TEST_FILES" | circleci tests run --verbose --split-by=timings --command="xargs yarn mocha --no-bail --exit"
+
+      - store_artifacts:
+          path: "./gas.csv"
 
   fork-test-new:
     parameters:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .idea
 *.log
 
+/tmp
+
 # Yarn v3
 .yarn/*
 .yarn/cache

--- a/e2e/debugTarget.js
+++ b/e2e/debugTarget.js
@@ -1,0 +1,14 @@
+require('supports-color'); // for prettier logs
+const debug = require('debug');
+const util = require('util');
+const fs = require('fs');
+
+const stream = process.env.DEBUG_TARGET
+  ? fs.createWriteStream(require('path').resolve(process.env.DEBUG_TARGET), { flags: 'a' })
+  : process.stderr;
+
+function log(...args) {
+  return stream.write(util.format(...args) + '\n');
+}
+
+debug.log = log;

--- a/e2e/gasLog.js
+++ b/e2e/gasLog.js
@@ -1,0 +1,45 @@
+const { ethers } = require('ethers');
+
+const GAS_REPORT = process.env.GAS_REPORT ? require('path').resolve(process.env.GAS_REPORT) : null;
+
+if (GAS_REPORT) {
+  require('fs').writeFileSync(
+    GAS_REPORT,
+    ['action', 'gasUsed', 'effectiveGasPrice', 'baseFeePerGas']
+      .map((value) => JSON.stringify(value))
+      .join(';') + '\n',
+    'utf8'
+  );
+}
+
+function gasLog({ action, log }) {
+  return async (txn) => {
+    if (!txn) {
+      return txn;
+    }
+    const provider = new ethers.providers.JsonRpcProvider(
+      process.env.RPC_URL || 'http://127.0.0.1:8545'
+    );
+    const block = await provider.getBlock(txn.blockNumber);
+    const gasInfo = {
+      action,
+      gasUsed: txn.gasUsed.toNumber(),
+      effectiveGasPrice: txn.effectiveGasPrice.toNumber(),
+      baseFeePerGas: block.baseFeePerGas.toNumber(),
+    };
+    log(gasInfo);
+    if (GAS_REPORT) {
+      await require('fs').promises.appendFile(
+        GAS_REPORT,
+        Object.values(gasInfo)
+          .map((value) => JSON.stringify(value))
+          .join(';') + '\n'
+      );
+    }
+    return txn;
+  };
+}
+
+module.exports = {
+  gasLog,
+};

--- a/e2e/gasLog.js
+++ b/e2e/gasLog.js
@@ -5,9 +5,7 @@ const GAS_REPORT = process.env.GAS_REPORT ? require('path').resolve(process.env.
 if (GAS_REPORT) {
   require('fs').writeFileSync(
     GAS_REPORT,
-    ['action', 'gasUsed', 'effectiveGasPrice', 'baseFeePerGas']
-      .map((value) => JSON.stringify(value))
-      .join(';') + '\n',
+    ['action', 'gasUsed', 'baseFeePerGas'].map((value) => JSON.stringify(value)).join(';') + '\n',
     'utf8'
   );
 }
@@ -24,7 +22,6 @@ function gasLog({ action, log }) {
     const gasInfo = {
       action,
       gasUsed: txn.gasUsed.toNumber(),
-      effectiveGasPrice: txn.effectiveGasPrice.toNumber(),
       baseFeePerGas: block.baseFeePerGas.toNumber(),
     };
     log(gasInfo);

--- a/e2e/inspect.js
+++ b/e2e/inspect.js
@@ -1,6 +1,8 @@
 const util = require('util');
 const { ethers } = require('ethers');
 
+require('./debugTarget');
+
 // util.inspect.defaultOptions.compact = true;
 // util.inspect.defaultOptions.breakLength = Infinity;
 util.inspect.defaultOptions.colors = true;

--- a/e2e/tasks/approveToken.js
+++ b/e2e/tasks/approveToken.js
@@ -2,6 +2,7 @@
 
 const { ethers } = require('ethers');
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+const { traceTxn } = require('../traceTxn');
 const { parseError } = require('../parseError');
 const { gasLog } = require('../gasLog');
 
@@ -22,10 +23,19 @@ async function approveToken({ privateKey, tokenAddress, spenderAddress }) {
   const symbol = await Token.symbol();
   log({ symbol, tokenAddress, spenderAddress });
 
-  const tx = await Token.approve(spenderAddress, ethers.constants.MaxUint256);
+  const args = [
+    //
+    spenderAddress,
+    ethers.constants.MaxUint256,
+  ];
+  const gasLimit = await Token.estimateGas
+    .approve(...args)
+    .catch(parseError)
+    .catch(() => 10_000_000);
+  const tx = await Token.approve(...args, { gasLimit: gasLimit.mul(2) }).catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, traceTxn(tx))
     .then(gasLog({ action: 'Token.approve', log }));
   return null;
 }

--- a/e2e/tasks/approveToken.js
+++ b/e2e/tasks/approveToken.js
@@ -2,6 +2,8 @@
 
 const { ethers } = require('ethers');
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 async function approveToken({ privateKey, tokenAddress, spenderAddress }) {
   const provider = new ethers.providers.JsonRpcProvider(
@@ -21,7 +23,10 @@ async function approveToken({ privateKey, tokenAddress, spenderAddress }) {
   log({ symbol, tokenAddress, spenderAddress });
 
   const tx = await Token.approve(spenderAddress, ethers.constants.MaxUint256);
-  await tx.wait();
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'Token.approve', log }));
   return null;
 }
 

--- a/e2e/tasks/borrowUsd.js
+++ b/e2e/tasks/borrowUsd.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 const { traceTxn } = require('../traceTxn');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);

--- a/e2e/tasks/borrowUsd.js
+++ b/e2e/tasks/borrowUsd.js
@@ -50,8 +50,8 @@ async function borrowUsd({ privateKey, accountId, symbol, amount, poolId }) {
   const tx = await CoreProxy.mintUsd(...args, { gasLimit: gasLimit.mul(2) }).catch(parseError);
   await tx
     .wait()
-    .then(({ events }) => log({ events }))
-    .catch(traceTxn(tx));
+    .then((txn) => log(txn.events) || txn, traceTxn(tx))
+    .then(gasLog({ action: 'CoreProxy.mintUsd', log }));
   return debt;
 }
 

--- a/e2e/tasks/burnDebt.js
+++ b/e2e/tasks/burnDebt.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -31,7 +32,10 @@ async function burnDebt({ wallet, accountId, symbol, poolId }) {
       oldDebt,
       { gasLimit: 10_000_000 }
     ).catch(parseError);
-    await tx.wait();
+    await tx
+      .wait()
+      .then((txn) => log(txn) || txn, parseError)
+      .then(gasLog({ action: 'CoreProxy.burnUsd', log }));
 
     const newDebt = await CoreProxy.callStatic.getPositionDebt(
       ethers.BigNumber.from(accountId),

--- a/e2e/tasks/burnDebt.js
+++ b/e2e/tasks/burnDebt.js
@@ -34,7 +34,7 @@ async function burnDebt({ wallet, accountId, symbol, poolId }) {
     ).catch(parseError);
     await tx
       .wait()
-      .then((txn) => log(txn) || txn, parseError)
+      .then((txn) => log(txn.events) || txn, parseError)
       .then(gasLog({ action: 'CoreProxy.burnUsd', log }));
 
     const newDebt = await CoreProxy.callStatic.getPositionDebt(

--- a/e2e/tasks/commitPerpsOrder.js
+++ b/e2e/tasks/commitPerpsOrder.js
@@ -43,7 +43,7 @@ async function commitPerpsOrder({ wallet, accountId, marketId, sizeDelta, settle
   );
   const commitReceipt = await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'PerpsMarketProxy.commitOrder', log }));
 
   const block = await wallet.provider.getBlock(commitReceipt.blockNumber);

--- a/e2e/tasks/commitPerpsOrder.js
+++ b/e2e/tasks/commitPerpsOrder.js
@@ -4,6 +4,7 @@ const { ethers } = require('ethers');
 const { getPythPrice } = require('./getPythPrice');
 const { getPerpsSettlementStrategy } = require('./getPerpsSettlementStrategy');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 const { getPerpsPosition } = require('./getPerpsPosition');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
@@ -40,9 +41,11 @@ async function commitPerpsOrder({ wallet, accountId, marketId, sizeDelta, settle
   const tx = await PerpsMarketProxy.commitOrder(params, { gasLimit: gasLimit.mul(2) }).catch(
     parseError
   );
-  await tx.wait().catch(parseError);
+  const commitReceipt = await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'PerpsMarketProxy.commitOrder', log }));
 
-  const commitReceipt = await tx.wait().catch(parseError);
   const block = await wallet.provider.getBlock(commitReceipt.blockNumber);
   const commitmentTime = block.timestamp;
   log({ commitmentTime: new Date(commitmentTime * 1000) });

--- a/e2e/tasks/configureMaximumMarketCollateral.js
+++ b/e2e/tasks/configureMaximumMarketCollateral.js
@@ -51,8 +51,8 @@ async function configureMaximumMarketCollateral({ marketId, symbol, targetAmount
     .catch(parseError);
   await tx
     .wait()
-    .then(({ events }) => log({ events }))
-    .catch(parseError);
+    .then((txn) => log(txn.events) || txn, parseError)
+    .then(gasLog({ action: 'CoreProxy.configureMaximumMarketCollateral', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
 
   log({ newMaximumumMarketCollateral: await getMaximumMarketCollateral({ marketId, symbol }) });

--- a/e2e/tasks/configureMaximumMarketCollateral.js
+++ b/e2e/tasks/configureMaximumMarketCollateral.js
@@ -5,6 +5,7 @@ const { setEthBalance } = require('./setEthBalance');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { getMaximumMarketCollateral } = require('./getMaximumMarketCollateral');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 

--- a/e2e/tasks/createAccount.js
+++ b/e2e/tasks/createAccount.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { getAccountOwner } = require('./getAccountOwner');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -24,7 +25,10 @@ async function createAccount({ wallet, accountId }) {
   const tx = await CoreProxy['createAccount(uint128)'](accountId, {
     gasLimit: gasLimit.mul(2),
   }).catch(parseError);
-  await tx.wait();
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'CoreProxy.createAccount(uint128)', log }));
 
   const newAccountOwner = await getAccountOwner({ accountId });
   log({ accountId, newAccountOwner });

--- a/e2e/tasks/createAccount.js
+++ b/e2e/tasks/createAccount.js
@@ -27,7 +27,7 @@ async function createAccount({ wallet, accountId }) {
   }).catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'CoreProxy.createAccount(uint128)', log }));
 
   const newAccountOwner = await getAccountOwner({ accountId });

--- a/e2e/tasks/createPerpsAccount.js
+++ b/e2e/tasks/createPerpsAccount.js
@@ -4,6 +4,7 @@ const { ethers } = require('ethers');
 // const crypto = require('crypto');
 const { getPerpsAccountOwner } = require('./getPerpsAccountOwner');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -27,7 +28,11 @@ async function createPerpsAccount({ wallet, accountId }) {
     accountId,
     { gasLimit: 10_000_000 }
   ).catch(parseError);
-  await tx.wait();
+
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'PerpsMarketProxy.createAccount(uint128)', log }));
 
   const newAccountOwner = await getPerpsAccountOwner({ accountId });
   log({ accountId, newAccountOwner });

--- a/e2e/tasks/createPerpsAccount.js
+++ b/e2e/tasks/createPerpsAccount.js
@@ -31,7 +31,7 @@ async function createPerpsAccount({ wallet, accountId }) {
 
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'PerpsMarketProxy.createAccount(uint128)', log }));
 
   const newAccountOwner = await getPerpsAccountOwner({ accountId });

--- a/e2e/tasks/delegateCollateral.js
+++ b/e2e/tasks/delegateCollateral.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 const { traceTxn } = require('../traceTxn');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);

--- a/e2e/tasks/delegateCollateral.js
+++ b/e2e/tasks/delegateCollateral.js
@@ -35,8 +35,8 @@ async function delegateCollateral({ privateKey, accountId, symbol, amount, poolI
   const tx = await CoreProxy.delegateCollateral(...args, { gasLimit: gasLimit.mul(2) });
   await tx
     .wait()
-    .then(({ events }) => log({ events }))
-    .catch(traceTxn(tx));
+    .then((txn) => log(txn.events) || txn, traceTxn(tx))
+    .then(gasLog({ action: 'CoreProxy.delegateCollateral', log }));
 
   return accountId;
 }

--- a/e2e/tasks/depositCollateral.js
+++ b/e2e/tasks/depositCollateral.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -19,14 +20,17 @@ async function depositCollateral({ privateKey, accountId, symbol, amount }) {
     require('../deployments/CoreProxy.json').abi,
     wallet
   );
-  const params = [
+  const args = [
     ethers.BigNumber.from(accountId),
     config.tokenAddress,
     ethers.utils.parseEther(`${amount}`),
   ];
-  const gasLimit = await CoreProxy.estimateGas.deposit(...params);
-  const tx = await CoreProxy.deposit(...params, { gasLimit: gasLimit.mul(2) }).catch(parseError);
-  await tx.wait();
+  const gasLimit = await CoreProxy.estimateGas.deposit(...args);
+  const tx = await CoreProxy.deposit(...args, { gasLimit: gasLimit.mul(2) }).catch(parseError);
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'CoreProxy.deposit', log }));
 
   return accountId;
 }

--- a/e2e/tasks/depositCollateral.js
+++ b/e2e/tasks/depositCollateral.js
@@ -29,7 +29,7 @@ async function depositCollateral({ privateKey, accountId, symbol, amount }) {
   const tx = await CoreProxy.deposit(...args, { gasLimit: gasLimit.mul(2) }).catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'CoreProxy.deposit', log }));
 
   return accountId;

--- a/e2e/tasks/doPriceUpdate.js
+++ b/e2e/tasks/doPriceUpdate.js
@@ -45,7 +45,7 @@ async function doPriceUpdate({ wallet, marketId, settlementStrategyId }) {
   }).catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'PriceVerificationContract.fulfillOracleQuery', log }));
 
   log({ marketId, feedId, updated: true });

--- a/e2e/tasks/doPriceUpdate.js
+++ b/e2e/tasks/doPriceUpdate.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { EvmPriceServiceConnection } = require('@pythnetwork/pyth-evm-js');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 const { getPerpsSettlementStrategy } = require('./getPerpsSettlementStrategy');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
@@ -42,7 +43,10 @@ async function doPriceUpdate({ wallet, marketId, settlementStrategyId }) {
   const tx = await PriceVerificationContract.fulfillOracleQuery(offchainDataEncoded, {
     value: ethers.BigNumber.from(1), // 1 wei,
   }).catch(parseError);
-  await tx.wait().catch(parseError);
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'PriceVerificationContract.fulfillOracleQuery', log }));
 
   log({ marketId, feedId, updated: true });
 }

--- a/e2e/tasks/doPriceUpdateForPyth.js
+++ b/e2e/tasks/doPriceUpdateForPyth.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { EvmPriceServiceConnection } = require('@pythnetwork/pyth-evm-js');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 const { traceTxn } = require('../traceTxn');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);

--- a/e2e/tasks/doPriceUpdateForPyth.js
+++ b/e2e/tasks/doPriceUpdateForPyth.js
@@ -112,8 +112,8 @@ async function doPriceUpdateForPyth({ wallet, feedId, priceVerificationContract 
   });
   await tx
     .wait()
-    .then(({ events }) => log({ events }))
-    .catch(traceTxn(tx));
+    .then((txn) => log(txn.events) || txn, traceTxn(tx))
+    .then(gasLog({ action: 'PriceVerificationContract.updatePriceFeeds', log }));
 }
 
 module.exports = {

--- a/e2e/tasks/doStrictPriceUpdate.js
+++ b/e2e/tasks/doStrictPriceUpdate.js
@@ -57,7 +57,7 @@ async function doStrictPriceUpdate({ wallet, marketId, settlementStrategyId, com
   }).catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'PriceVerificationContract.fulfillOracleQuery', log }));
 
   log({ marketId, feedId, updated: true });

--- a/e2e/tasks/doStrictPriceUpdate.js
+++ b/e2e/tasks/doStrictPriceUpdate.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { EvmPriceServiceConnection } = require('@pythnetwork/pyth-evm-js');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 const { getPerpsSettlementStrategy } = require('./getPerpsSettlementStrategy');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
@@ -54,7 +55,10 @@ async function doStrictPriceUpdate({ wallet, marketId, settlementStrategyId, com
   const tx = await PriceVerificationContract.fulfillOracleQuery(offchainDataEncoded, {
     value: ethers.BigNumber.from(1), // 1 wei,
   }).catch(parseError);
-  await tx.wait().catch(parseError);
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'PriceVerificationContract.fulfillOracleQuery', log }));
 
   log({ marketId, feedId, updated: true });
 }

--- a/e2e/tasks/modifyPerpsCollateral.js
+++ b/e2e/tasks/modifyPerpsCollateral.js
@@ -32,7 +32,7 @@ async function modifyPerpsCollateral({ wallet, accountId, deltaAmount }) {
   );
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'PerpsMarketProxy.modifyCollateral', log }));
 
   const currentAmount = await getPerpsCollateral({ accountId });

--- a/e2e/tasks/modifyPerpsCollateral.js
+++ b/e2e/tasks/modifyPerpsCollateral.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { getPerpsCollateral } = require('./getPerpsCollateral');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -29,7 +30,10 @@ async function modifyPerpsCollateral({ wallet, accountId, deltaAmount }) {
   const tx = await PerpsMarketProxy.modifyCollateral(...args, { gasLimit: gasLimit.mul(2) }).catch(
     parseError
   );
-  await tx.wait().catch(parseError);
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'PerpsMarketProxy.modifyCollateral', log }));
 
   const currentAmount = await getPerpsCollateral({ accountId });
   log({ address: wallet.address, accountId, deltaAmount, currentAmount });

--- a/e2e/tasks/setConfigUint.js
+++ b/e2e/tasks/setConfigUint.js
@@ -5,6 +5,8 @@ const { setEthBalance } = require('./setEthBalance');
 const { getConfigUint } = require('./getConfigUint');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 async function setConfigUint({ key, value }) {
   const provider = new ethers.providers.JsonRpcProvider(
@@ -35,7 +37,10 @@ async function setConfigUint({ key, value }) {
     ethers.utils.hexZeroPad(ethers.utils.hexlify(value), 32),
     { gasLimit: 10_000_000 }
   );
-  await tx.wait();
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'CoreProxy.setConfig', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
 
   const newValue = await getConfigUint(key);

--- a/e2e/tasks/setConfigUint.js
+++ b/e2e/tasks/setConfigUint.js
@@ -39,7 +39,7 @@ async function setConfigUint({ key, value }) {
   );
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'CoreProxy.setConfig', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
 

--- a/e2e/tasks/setMintableTokenBalance.js
+++ b/e2e/tasks/setMintableTokenBalance.js
@@ -2,8 +2,9 @@
 
 const { ethers } = require('ethers');
 const { setEthBalance } = require('./setEthBalance');
-
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 async function setMintableTokenBalance({ privateKey, tokenAddress, balance }) {
   const provider = new ethers.providers.JsonRpcProvider(
@@ -47,7 +48,10 @@ async function setMintableTokenBalance({ privateKey, tokenAddress, balance }) {
     ethers.utils.parseUnits(`${balance - oldBalance}`, decimals),
     wallet.address
   );
-  await tx.wait();
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'Token.mint', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
 
   const newBalance = parseFloat(

--- a/e2e/tasks/setMintableTokenBalance.js
+++ b/e2e/tasks/setMintableTokenBalance.js
@@ -50,7 +50,7 @@ async function setMintableTokenBalance({ privateKey, tokenAddress, balance }) {
   );
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'Token.mint', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
 

--- a/e2e/tasks/setPerpsSettlementDelays.js
+++ b/e2e/tasks/setPerpsSettlementDelays.js
@@ -4,6 +4,8 @@ const { ethers } = require('ethers');
 const { setEthBalance } = require('./setEthBalance');
 const { getPerpsSettlementStrategy } = require('./getPerpsSettlementStrategy');
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 async function setSettlementDelays({
   settlementStrategyId,
@@ -49,7 +51,10 @@ async function setSettlementDelays({
     strategy,
     { gasLimit: 10_000_000 }
   );
-  await tx.wait();
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'PerpsMarketProxy.setSettlementStrategy', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
 
   const newStrategy = await getPerpsSettlementStrategy({ marketId, settlementStrategyId });

--- a/e2e/tasks/setPerpsSettlementDelays.js
+++ b/e2e/tasks/setPerpsSettlementDelays.js
@@ -53,7 +53,7 @@ async function setSettlementDelays({
   );
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'PerpsMarketProxy.setSettlementStrategy', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
 

--- a/e2e/tasks/setSnxBalance.js
+++ b/e2e/tasks/setSnxBalance.js
@@ -90,7 +90,7 @@ async function setSnxBalance({ address, balance }) {
     .catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'Token.transfer', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
   //  }

--- a/e2e/tasks/setSpotWrapper.js
+++ b/e2e/tasks/setSpotWrapper.js
@@ -48,7 +48,7 @@ async function setSpotWrapper({ marketId, symbol, targetAmount }) {
     .catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'SpotMarketProxy.setWrapper', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
 }

--- a/e2e/tasks/setSpotWrapper.js
+++ b/e2e/tasks/setSpotWrapper.js
@@ -4,6 +4,7 @@ const { ethers } = require('ethers');
 const { setEthBalance } = require('./setEthBalance');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -47,8 +48,8 @@ async function setSpotWrapper({ marketId, symbol, targetAmount }) {
     .catch(parseError);
   await tx
     .wait()
-    .then((data) => console.log(JSON.stringify(data, null, 2)))
-    .catch(parseError);
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'SpotMarketProxy.setWrapper', log }));
   await provider.send('anvil_stopImpersonatingAccount', [owner]);
 }
 

--- a/e2e/tasks/setUSDCTokenBalance.js
+++ b/e2e/tasks/setUSDCTokenBalance.js
@@ -49,7 +49,7 @@ async function setUSDCTokenBalance({ wallet, balance }) {
   );
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'Token.transfer', log }));
   await wallet.provider.send('anvil_stopImpersonatingAccount', [friendlyWhale]);
 

--- a/e2e/tasks/setUSDCTokenBalance.js
+++ b/e2e/tasks/setUSDCTokenBalance.js
@@ -3,6 +3,8 @@
 const { ethers } = require('ethers');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { setEthBalance } = require('./setEthBalance');
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -41,11 +43,14 @@ async function setUSDCTokenBalance({ wallet, balance }) {
 
   await wallet.provider.send('anvil_impersonateAccount', [friendlyWhale]);
   const signer = wallet.provider.getSigner(friendlyWhale);
-  const transferTx = await Token.connect(signer).transfer(
+  const tx = await Token.connect(signer).transfer(
     wallet.address,
     ethers.utils.parseUnits(`${balance - oldBalance}`, decimals)
   );
-  await transferTx.wait();
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'Token.transfer', log }));
   await wallet.provider.send('anvil_stopImpersonatingAccount', [friendlyWhale]);
 
   const newBalance = parseFloat(

--- a/e2e/tasks/settlePerpsOrder.js
+++ b/e2e/tasks/settlePerpsOrder.js
@@ -2,6 +2,7 @@
 
 const { ethers } = require('ethers');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 const { getPerpsPosition } = require('./getPerpsPosition');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
@@ -22,7 +23,10 @@ async function settlePerpsOrder({ wallet, accountId, marketId }) {
   const tx = await PerpsMarketProxy.settleOrder(accountId, { gasLimit: gasLimit.mul(2) }).catch(
     parseError
   );
-  await tx.wait().catch(parseError);
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'PerpsMarketProxy.settleOrder', log }));
 
   const newPosition = await getPerpsPosition({ accountId, marketId });
   log({ newPosition });

--- a/e2e/tasks/settlePerpsOrder.js
+++ b/e2e/tasks/settlePerpsOrder.js
@@ -25,7 +25,7 @@ async function settlePerpsOrder({ wallet, accountId, marketId }) {
   );
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'PerpsMarketProxy.settleOrder', log }));
 
   const newPosition = await getPerpsPosition({ accountId, marketId });

--- a/e2e/tasks/swapToSusd.js
+++ b/e2e/tasks/swapToSusd.js
@@ -24,7 +24,7 @@ async function swapToSusd({ wallet, marketId, amount }) {
   const tx = await SpotMarketProxy.sell(...args, { gasLimit: gasLimit.mul(2) }).catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'SpotMarketProxy.sell', log }));
 }
 

--- a/e2e/tasks/undelegateCollateral.js
+++ b/e2e/tasks/undelegateCollateral.js
@@ -77,7 +77,7 @@ async function undelegateCollateral({ wallet, accountId, symbol, targetAmount, p
   );
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'CoreProxy.burnUsd + CoreProxy.delegateCollateral', log }));
 
   const newDebt = await CoreProxy.callStatic.getPositionDebt(

--- a/e2e/tasks/undelegateCollateral.js
+++ b/e2e/tasks/undelegateCollateral.js
@@ -4,6 +4,7 @@ const { ethers } = require('ethers');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { mineBlock } = require('./mineBlock');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -74,7 +75,10 @@ async function undelegateCollateral({ wallet, accountId, symbol, targetAmount, p
   const tx = await Multicall.tryBlockAndAggregate(...args, { gasLimit: gasLimit.mul(2) }).catch(
     parseError
   );
-  await tx.wait().catch(parseError);
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'CoreProxy.burnUsd + CoreProxy.delegateCollateral', log }));
 
   const newDebt = await CoreProxy.callStatic.getPositionDebt(
     ethers.BigNumber.from(accountId),

--- a/e2e/tasks/unwrapCollateral.js
+++ b/e2e/tasks/unwrapCollateral.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -55,7 +56,10 @@ async function unwrapCollateral({ wallet, symbol, amount }) {
   log({ args });
   const gas = await SpotMarket.estimateGas.unwrap(...args).catch(parseError);
   const tx = await SpotMarket.unwrap(...args, { gasLimit: gas.mul(2) }).catch(parseError);
-  await tx.wait();
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'SpotMarket.unwrap', log }));
   const newBalance_token = parseFloat(
     ethers.utils.formatUnits(await CollateralToken.balanceOf(wallet.address), collateralDecimals)
   );

--- a/e2e/tasks/unwrapCollateral.js
+++ b/e2e/tasks/unwrapCollateral.js
@@ -58,7 +58,7 @@ async function unwrapCollateral({ wallet, symbol, amount }) {
   const tx = await SpotMarket.unwrap(...args, { gasLimit: gas.mul(2) }).catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'SpotMarket.unwrap', log }));
   const newBalance_token = parseFloat(
     ethers.utils.formatUnits(await CollateralToken.balanceOf(wallet.address), collateralDecimals)

--- a/e2e/tasks/withdrawCollateral.js
+++ b/e2e/tasks/withdrawCollateral.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -26,7 +27,10 @@ async function withdrawCollateral({ privateKey, accountId, symbol, amount }) {
     ethers.utils.parseEther(`${amount}`),
     { gasLimit: 10_000_000 }
   ).catch(parseError);
-  await tx.wait();
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'CoreProxy.withdraw', log }));
 
   return accountId;
 }

--- a/e2e/tasks/withdrawCollateral.js
+++ b/e2e/tasks/withdrawCollateral.js
@@ -29,7 +29,7 @@ async function withdrawCollateral({ privateKey, accountId, symbol, amount }) {
   ).catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'CoreProxy.withdraw', log }));
 
   return accountId;

--- a/e2e/tasks/wrapCollateral.js
+++ b/e2e/tasks/wrapCollateral.js
@@ -59,7 +59,7 @@ async function wrapCollateral({ wallet, symbol, amount }) {
   const tx = await SpotMarket.wrap(...args, { gasLimit: gas.mul(2) }).catch(parseError);
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'SpotMarket.wrap', log }));
   const newBalance_token = parseFloat(
     ethers.utils.formatUnits(await CollateralToken.balanceOf(wallet.address), collateralDecimals)

--- a/e2e/tasks/wrapCollateral.js
+++ b/e2e/tasks/wrapCollateral.js
@@ -3,6 +3,7 @@
 const { ethers } = require('ethers');
 const { getCollateralConfig } = require('./getCollateralConfig');
 const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -56,7 +57,10 @@ async function wrapCollateral({ wallet, symbol, amount }) {
   log({ args });
   const gas = await SpotMarket.estimateGas.wrap(...args).catch(parseError);
   const tx = await SpotMarket.wrap(...args, { gasLimit: gas.mul(2) }).catch(parseError);
-  await tx.wait();
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'SpotMarket.wrap', log }));
   const newBalance_token = parseFloat(
     ethers.utils.formatUnits(await CollateralToken.balanceOf(wallet.address), collateralDecimals)
   );

--- a/e2e/tasks/wrapEth.js
+++ b/e2e/tasks/wrapEth.js
@@ -35,7 +35,7 @@ async function wrapEth({ privateKey, amount }) {
   });
   await tx
     .wait()
-    .then((txn) => log(txn) || txn, parseError)
+    .then((txn) => log(txn.events) || txn, parseError)
     .then(gasLog({ action: 'WethToken.deposit', log }));
   const newBalance = parseFloat(
     ethers.utils.formatUnits(await WethToken.balanceOf(wallet.address))

--- a/e2e/tasks/wrapEth.js
+++ b/e2e/tasks/wrapEth.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 const { ethers } = require('ethers');
+const { getCollateralConfig } = require('./getCollateralConfig');
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
 
 const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
 
@@ -16,21 +19,10 @@ async function wrapEth({ privateKey, amount }) {
   );
   const wallet = new ethers.Wallet(privateKey, provider);
 
-  const CoreProxy = new ethers.Contract(
-    require('../deployments/CoreProxy.json').address,
-    require('../deployments/CoreProxy.json').abi,
-    wallet
-  );
-  const collateralConfigs = await CoreProxy.getCollateralConfigurations(true);
-  const collaterals = await Promise.all(
-    collateralConfigs.map(async (config) => {
-      const contract = new ethers.Contract(config.tokenAddress, erc20Abi, wallet);
-      const symbol = await contract.symbol();
-      return { contract, symbol };
-    })
-  );
-  const weth = collaterals.find(({ symbol }) => symbol === 'WETH').contract;
-  const balance = parseFloat(ethers.utils.formatUnits(await weth.balanceOf(wallet.address)));
+  const config = await getCollateralConfig('WETH');
+  const WethToken = new ethers.Contract(config.tokenAddress, erc20Abi, wallet);
+
+  const balance = parseFloat(ethers.utils.formatUnits(await WethToken.balanceOf(wallet.address)));
   log({ oldBalance: balance });
 
   if (balance >= amount) {
@@ -38,11 +30,16 @@ async function wrapEth({ privateKey, amount }) {
     return balance;
   }
 
-  const wrapTx = await weth.deposit({
+  const tx = await WethToken.deposit({
     value: ethers.utils.hexValue(ethers.utils.parseEther(`${amount}`).toHexString()),
   });
-  await wrapTx.wait();
-  const newBalance = parseFloat(ethers.utils.formatUnits(await weth.balanceOf(wallet.address)));
+  await tx
+    .wait()
+    .then((txn) => log(txn) || txn, parseError)
+    .then(gasLog({ action: 'WethToken.deposit', log }));
+  const newBalance = parseFloat(
+    ethers.utils.formatUnits(await WethToken.balanceOf(wallet.address))
+  );
   log({ newBalance: newBalance });
   return newBalance;
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "numbro": "^2.4.0",
     "prettier": "^3.2.2",
     "prettier-plugin-toml": "^2.0.1",
-    "solc": "0.8.21"
+    "solc": "0.8.21",
+    "supports-color": "^8.1.1"
   },
   "mocha": {
     "timeout": "2m",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4794,7 +4794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:8.1.1":
+"supports-color@npm:8.1.1, supports-color@npm:^8.1.1":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
   dependencies:
@@ -4843,6 +4843,7 @@ __metadata:
     prettier: "npm:^3.2.2"
     prettier-plugin-toml: "npm:^2.0.1"
     solc: "npm:0.8.21"
+    supports-color: "npm:^8.1.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Currently will generate CSV file for each test run. And keeps that file in CircleCI artifacts.
We can also push it to some repo (maybe docs repo?). But that would be done separately if necessary.

This is a first iteration and only the minimal set of fields is exported:
- `gasUsed`
- `baseFeePerGas`

As we are running this on a fork the values might not be exactly same as they would be on real chain


csv looks like this 


<img width="859" alt="_ 2024-01-29 at 14 18 05" src="https://github.com/Synthetixio/synthetix-deployments/assets/28145325/4e532c25-e75f-4444-a0fa-214d3947f82f">
