### PR TITLE
Deploy Spartan Council Pool Rewards

### DIFF
--- a/e2e/generateDeployments.js
+++ b/e2e/generateDeployments.js
@@ -109,6 +109,7 @@ async function run() {
         fakeCollateral.contracts.MintableToken;
     }
   }
+  mintableToken('snx_mock_collateral');
   mintableToken('usdc_mock_collateral');
   mintableToken('mintableToken');
 

--- a/e2e/generateDeployments.js
+++ b/e2e/generateDeployments.js
@@ -100,6 +100,13 @@ async function run() {
       perpsFactory.contracts.PerpsAccountProxy ?? perpsFactory.contracts.AccountProxy;
   }
 
+  const rd =
+    deployments?.state?.[`provision.spartan_council_pool_rewards`]?.artifacts?.imports
+      ?.spartan_council_pool_rewards;
+  if (rd) {
+    contracts[`RewardsDistributorForSpartanCouncilPool`] = rd.contracts.RewardsDistributor;
+  }
+
   function mintableToken(provisionStep) {
     const fakeCollateral =
       deployments?.state?.[`provision.${provisionStep}`]?.artifacts?.imports?.[provisionStep];

--- a/e2e/tasks/claimRewards.js
+++ b/e2e/tasks/claimRewards.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
+
+const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+
+async function claimRewards({ wallet, accountId, poolId, collateralType, distributorAddress }) {
+  const CoreProxy = new ethers.Contract(
+    require('../deployments/CoreProxy.json').address,
+    require('../deployments/CoreProxy.json').abi,
+    wallet
+  );
+
+  const args = [
+    //
+    accountId,
+    poolId,
+    collateralType,
+    distributorAddress,
+  ];
+  log({ accountId, poolId, collateralType, distributorAddress });
+
+  const gasLimit = await CoreProxy.estimateGas.claimRewards(...args).catch(parseError);
+  const tx = await CoreProxy.claimRewards(...args, { gasLimit: gasLimit.mul(2) }).catch(parseError);
+  await tx
+    .wait()
+    .then((txn) => log(txn.events) || txn, parseError)
+    .then(gasLog({ action: 'CoreProxy.claimRewards', log }));
+
+  return null;
+}
+
+module.exports = {
+  claimRewards,
+};
+
+if (require.main === module) {
+  require('../inspect');
+
+  const [pk, accountId, poolId, collateralType, distributorAddress] = process.argv.slice(2);
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+  const wallet = new ethers.Wallet(pk, provider);
+
+  claimRewards({
+    wallet,
+    accountId,
+    poolId,
+    collateralType,
+    distributorAddress,
+  }).then((data) => console.log(JSON.stringify(data, null, 2)));
+}

--- a/e2e/tasks/distributeRewards.js
+++ b/e2e/tasks/distributeRewards.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
+
+const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+
+async function distributeRewards({
+  wallet,
+  distributorAddress,
+  poolId,
+  collateralType,
+  amount,
+  start,
+  duration,
+}) {
+  const RewardsDistributor = new ethers.Contract(
+    distributorAddress,
+    [
+      'function distributeRewards(uint128 poolId, address collateralType, uint256 amount, uint64 start, uint32 duration)',
+    ],
+    wallet
+  );
+
+  const args = [
+    //
+    poolId,
+    collateralType,
+    amount,
+    start,
+    duration,
+  ];
+  log({ poolId, collateralType, amount, start, duration });
+  const gasLimit = await RewardsDistributor.estimateGas
+    .distributeRewards(...args)
+    .catch(parseError);
+  const tx = await RewardsDistributor.distributeRewards(...args, {
+    gasLimit: gasLimit.mul(2),
+  }).catch(parseError);
+  await tx
+    .wait()
+    .then((txn) => log(txn.events) || txn, parseError)
+    .then(gasLog({ action: 'RewardsDistributor.distributeRewards', log }));
+
+  return null;
+}
+
+module.exports = {
+  distributeRewards,
+};
+
+if (require.main === module) {
+  require('../inspect');
+
+  const [pk, distributorAddress, poolId, collateralType, amount, start, duration] =
+    process.argv.slice(2);
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+  const wallet = new ethers.Wallet(pk, provider);
+
+  distributeRewards({
+    wallet,
+    distributorAddress,
+    poolId,
+    collateralType,
+    amount,
+    start,
+    duration,
+  }).then((data) => console.log(JSON.stringify(data, null, 2)));
+}

--- a/e2e/tasks/getAvailableRewards.js
+++ b/e2e/tasks/getAvailableRewards.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+
+const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+
+async function getAvailableRewards({ distributorAddress, accountId, poolId, collateralType }) {
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+
+  const CoreProxy = new ethers.Contract(
+    require('../deployments/CoreProxy.json').address,
+    require('../deployments/CoreProxy.json').abi,
+    provider
+  );
+
+  const availableRewards = await CoreProxy.getAvailableRewards(
+    accountId,
+    poolId,
+    collateralType,
+    distributorAddress
+  );
+  log({ availableRewards });
+
+  return parseFloat(ethers.utils.formatEther(availableRewards));
+}
+
+module.exports = {
+  getAvailableRewards,
+};
+
+if (require.main === module) {
+  require('../inspect');
+  const [distributorAddress, accountId, poolId, collateralType] = process.argv.slice(2);
+  getAvailableRewards({ distributorAddress, accountId, poolId, collateralType }).then((data) =>
+    console.log(JSON.stringify(data, null, 2))
+  );
+}

--- a/e2e/tasks/getPoolOwner.js
+++ b/e2e/tasks/getPoolOwner.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+
+async function getPoolOwner({ poolId }) {
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+
+  const CoreProxy = new ethers.Contract(
+    require('../deployments/CoreProxy.json').address,
+    require('../deployments/CoreProxy.json').abi,
+    provider
+  );
+
+  const poolOwner = await CoreProxy.getPoolOwner(poolId);
+
+  return poolOwner;
+}
+
+module.exports = {
+  getPoolOwner,
+};
+
+if (require.main === module) {
+  require('../inspect');
+  const [poolId] = process.argv.slice(2);
+  getPoolOwner({ poolId }).then((data) => console.log(JSON.stringify(data, null, 2)));
+}

--- a/e2e/tasks/getTokenRewardsDistributorInfo.js
+++ b/e2e/tasks/getTokenRewardsDistributorInfo.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+
+const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+
+async function getTokenRewardsDistributorInfo({ distributorAddress }) {
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+  const RewardsDistributor = new ethers.Contract(
+    distributorAddress,
+    [
+      'function name() view returns (string)',
+      'function poolId() view returns (uint128)',
+      'function collateralType() view returns (address)',
+      'function payoutToken() view returns (address)',
+      'function precision() view returns (uint256)',
+      'function token() view returns (address)',
+      'function rewardManager() view returns (address)',
+      'function shouldFailPayout() view returns (bool)',
+    ],
+    provider
+  );
+  const [
+    name,
+    poolId,
+    collateralType,
+    payoutToken,
+    precision,
+    token,
+    rewardManager,
+    shouldFailPayout,
+  ] = await Promise.all([
+    RewardsDistributor.name().catch(() => null),
+    RewardsDistributor.poolId().catch(() => null),
+    RewardsDistributor.collateralType().catch(() => null),
+    RewardsDistributor.payoutToken().catch(() => null),
+    RewardsDistributor.precision().catch(() => null),
+    RewardsDistributor.token().catch(() => null),
+    RewardsDistributor.rewardManager().catch(() => null),
+    RewardsDistributor.shouldFailPayout().catch(() => null),
+  ]);
+
+  log({
+    name,
+    poolId,
+    collateralType,
+    payoutToken,
+    precision,
+    token,
+    rewardManager,
+    shouldFailPayout,
+  });
+
+  return {
+    name,
+    poolId,
+    collateralType,
+    payoutToken,
+    precision,
+    token,
+    rewardManager,
+    shouldFailPayout,
+  };
+}
+
+module.exports = {
+  getTokenRewardsDistributorInfo,
+};
+
+if (require.main === module) {
+  require('../inspect');
+  const [distributorAddress] = process.argv.slice(2);
+  getTokenRewardsDistributorInfo({ distributorAddress }).then((data) =>
+    console.log(JSON.stringify(data, null, 2))
+  );
+}

--- a/e2e/tasks/getTokenRewardsDistributorRewardsAmount.js
+++ b/e2e/tasks/getTokenRewardsDistributorRewardsAmount.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+
+const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+
+async function getTokenRewardsDistributorRewardsAmount({ distributorAddress }) {
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+  const RewardsDistributor = new ethers.Contract(
+    distributorAddress,
+    ['function rewardsAmount() view returns (uint256)'],
+    provider
+  );
+  const rewardsAmount = await RewardsDistributor.rewardsAmount().catch(() => null);
+  log({ rewardsAmount });
+
+  return parseFloat(ethers.utils.formatEther(rewardsAmount));
+}
+
+module.exports = {
+  getTokenRewardsDistributorRewardsAmount,
+};
+
+if (require.main === module) {
+  require('../inspect');
+  const [distributorAddress] = process.argv.slice(2);
+  getTokenRewardsDistributorRewardsAmount({ distributorAddress }).then((data) =>
+    console.log(JSON.stringify(data, null, 2))
+  );
+}

--- a/e2e/tasks/setPermissionlessTokenBalance.js
+++ b/e2e/tasks/setPermissionlessTokenBalance.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
+
+async function setPermissionlessTokenBalance({ privateKey, tokenAddress, balance }) {
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+  const wallet = new ethers.Wallet(privateKey, provider);
+
+  const Token = new ethers.Contract(
+    tokenAddress,
+    [
+      'function symbol() view returns (string)',
+      'function decimals() view returns (uint8)',
+      'function balanceOf(address account) view returns (uint256)',
+      'function mint(uint256 amount, address to)',
+    ],
+    wallet
+  );
+  const decimals = await Token.decimals();
+  const symbol = await Token.symbol();
+
+  const oldBalance = parseFloat(
+    ethers.utils.formatUnits(await Token.balanceOf(wallet.address), decimals)
+  );
+  log({ symbol, tokenAddress, oldBalance });
+
+  if (oldBalance > balance) {
+    log({ result: 'SKIP' });
+    return;
+  }
+
+  const tx = await Token.connect(wallet).mint(
+    ethers.utils.parseUnits(`${balance - oldBalance}`, decimals),
+    wallet.address
+  );
+  await tx
+    .wait()
+    .then((txn) => log(txn.events) || txn, parseError)
+    .then(gasLog({ action: 'Token.mint', log }));
+
+  const newBalance = parseFloat(
+    ethers.utils.formatUnits(await Token.balanceOf(wallet.address), decimals)
+  );
+  log({ symbol, tokenAddress, newBalance });
+
+  return null;
+}
+
+module.exports = {
+  setPermissionlessTokenBalance,
+};
+
+if (require.main === module) {
+  require('../inspect');
+  const [privateKey, tokenAddress, balance] = process.argv.slice(2);
+  setPermissionlessTokenBalance({ privateKey, tokenAddress, balance }).then((data) =>
+    console.log(JSON.stringify(data, null, 2))
+  );
+}

--- a/e2e/tasks/transferToken.js
+++ b/e2e/tasks/transferToken.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+const { ethers } = require('ethers');
+const log = require('debug')(`e2e:${require('path').basename(__filename, '.js')}`);
+const { parseError } = require('../parseError');
+const { gasLog } = require('../gasLog');
+
+async function transferToken({ privateKey, tokenAddress, targetWalletAddress, amount }) {
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+  const wallet = new ethers.Wallet(privateKey, provider);
+
+  const Token = new ethers.Contract(
+    tokenAddress,
+    [
+      'function symbol() view returns (string)',
+      'function decimals() view returns (uint8)',
+      'function balanceOf(address account) view returns (uint256)',
+      'function transfer(address to, uint256 amount) returns (bool)',
+    ],
+    wallet
+  );
+  const decimals = await Token.decimals();
+  const symbol = await Token.symbol();
+
+  const oldBalanceSource = parseFloat(
+    ethers.utils.formatUnits(await Token.balanceOf(wallet.address), decimals)
+  );
+  const oldBalanceTarget = parseFloat(
+    ethers.utils.formatUnits(await Token.balanceOf(targetWalletAddress), decimals)
+  );
+  log({ symbol, tokenAddress, oldBalanceSource, oldBalanceTarget });
+
+  const tx = await Token.connect(wallet).transfer(
+    targetWalletAddress,
+    ethers.utils.parseUnits(`${amount}`, decimals)
+  );
+  await tx
+    .wait()
+    .then((txn) => log(txn.events) || txn, parseError)
+    .then(gasLog({ action: 'Token.transfer', log }));
+
+  const newBalanceSource = parseFloat(
+    ethers.utils.formatUnits(await Token.balanceOf(wallet.address), decimals)
+  );
+  const newBalanceTarget = parseFloat(
+    ethers.utils.formatUnits(await Token.balanceOf(targetWalletAddress), decimals)
+  );
+  log({ symbol, tokenAddress, newBalanceSource, newBalanceTarget });
+
+  return null;
+}
+
+module.exports = {
+  transferToken,
+};
+
+if (require.main === module) {
+  require('../inspect');
+  const [privateKey, tokenAddress, targetWalletAddress, amount] = process.argv.slice(2);
+  transferToken({ privateKey, tokenAddress, targetWalletAddress, amount }).then((data) =>
+    console.log(JSON.stringify(data, null, 2))
+  );
+}

--- a/e2e/tests/omnibus-base-sepolia-andromeda.toml/Rewards.e2e.js
+++ b/e2e/tests/omnibus-base-sepolia-andromeda.toml/Rewards.e2e.js
@@ -1,0 +1,304 @@
+const crypto = require('crypto');
+const assert = require('assert');
+const { ethers } = require('ethers');
+require('../../inspect');
+const log = require('debug')(`e2e:${require('path').basename(__filename, '.e2e.js')}`);
+
+const { getEthBalance } = require('../../tasks/getEthBalance');
+const { setEthBalance } = require('../../tasks/setEthBalance');
+const { setMintableTokenBalance } = require('../../tasks/setMintableTokenBalance');
+const { wrapCollateral } = require('../../tasks/wrapCollateral');
+const { getAccountOwner } = require('../../tasks/getAccountOwner');
+const { createAccount } = require('../../tasks/createAccount');
+const { getCollateralConfig } = require('../../tasks/getCollateralConfig');
+const { getCollateralBalance } = require('../../tasks/getCollateralBalance');
+const { getAccountCollateral } = require('../../tasks/getAccountCollateral');
+const { isCollateralApproved } = require('../../tasks/isCollateralApproved');
+const { approveCollateral } = require('../../tasks/approveCollateral');
+const { depositCollateral } = require('../../tasks/depositCollateral');
+const { delegateCollateral } = require('../../tasks/delegateCollateral');
+const { doPriceUpdate } = require('../../tasks/doPriceUpdate');
+const { setSpotWrapper } = require('../../tasks/setSpotWrapper');
+const {
+  configureMaximumMarketCollateral,
+} = require('../../tasks/configureMaximumMarketCollateral');
+const { syncTime } = require('../../tasks/syncTime');
+
+describe(require('path').basename(__filename, '.e2e.js'), function () {
+  const accountId = parseInt(`1337${crypto.randomInt(1000)}`);
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+  const wallet = ethers.Wallet.createRandom().connect(provider);
+  const address = wallet.address;
+  const privateKey = wallet.privateKey;
+
+  let snapshot;
+
+  before('Create snapshot', async () => {
+    snapshot = await provider.send('evm_snapshot', []);
+    log('Create snapshot', { snapshot });
+  });
+
+  after('Restore snapshot', async () => {
+    log('Restore snapshot', { snapshot });
+    await provider.send('evm_revert', [snapshot]);
+  });
+
+  it.only('should sync time of the fork', async () => {
+    await syncTime();
+  });
+
+  it.only('should create new random wallet', async () => {
+    log({ wallet: wallet.address, pk: wallet.privateKey });
+    assert.ok(wallet.address);
+  });
+
+  it.only('should set ETH balance to 100', async () => {
+    assert.equal(await getEthBalance({ address }), 0, 'New wallet has 0 ETH balance');
+    await setEthBalance({ address, balance: 100 });
+    assert.equal(await getEthBalance({ address }), 100);
+  });
+
+  it.only('should set fwSNX balance to 1_000_000', async () => {
+    const {
+      contracts: { FakeCollateralfwSNX: tokenAddress },
+    } = require('../../deployments/meta.json');
+    const { getTokenBalance } = require('../../tasks/getTokenBalance');
+    const { setPermissionlessTokenBalance } = require('../../tasks/setPermissionlessTokenBalance');
+
+    assert.equal(
+      await getTokenBalance({ walletAddress: address, tokenAddress }),
+      0,
+      'New wallet has 0 fwSNX balance'
+    );
+    await setPermissionlessTokenBalance({ privateKey, tokenAddress, balance: 1_000_000 });
+    assert.equal(await getTokenBalance({ walletAddress: address, tokenAddress }), 1_000_000);
+  });
+
+  it.only('should distribute 1_000_000 fwSNX rewards', async () => {
+    const deployments = require('../../deployments/cannon.json');
+    const rd =
+      deployments?.state?.[`provision.spartan_council_pool_rewards`]?.artifacts?.imports
+        ?.spartan_council_pool_rewards?.contracts?.RewardsDistributor;
+    assert.ok(rd);
+    const RewardsDistributor = new ethers.Contract(rd.address, rd.abi, provider);
+
+    const {
+      contracts: { FakeCollateralfwSNX: tokenAddress },
+    } = require('../../deployments/meta.json');
+    const { getTokenBalance } = require('../../tasks/getTokenBalance');
+    const { transferToken } = require('../../tasks/transferToken');
+    const { parseError } = require('../../parseError');
+    const { gasLog } = require('../../gasLog');
+
+    assert.equal(
+      await getTokenBalance({ walletAddress: RewardsDistributor.address, tokenAddress }),
+      0
+    );
+    await transferToken({
+      privateKey,
+      tokenAddress,
+      targetWalletAddress: RewardsDistributor.address,
+      amount: 1_000_000,
+    });
+    assert.equal(
+      await getTokenBalance({ walletAddress: RewardsDistributor.address, tokenAddress }),
+      1_000_000
+    );
+
+    const poolId = 1;
+
+    const { tokenAddress: collateralType } = await getCollateralConfig('sUSDC');
+    const amount = ethers.utils.parseEther(`${1_000_000}`);
+    const start = Math.floor(Date.now() / 1000);
+    const duration = 10;
+
+    const CoreProxy = new ethers.Contract(
+      require('../../deployments/CoreProxy.json').address,
+      require('../../deployments/CoreProxy.json').abi,
+      provider
+    );
+
+    const poolOwner = await CoreProxy.getPoolOwner(poolId);
+    log({ poolOwner });
+    await provider.send('anvil_impersonateAccount', [poolOwner]);
+    const signer = provider.getSigner(poolOwner);
+
+    /* [
+      "0xF4Df9Dd327Fd30695d478c3c8a2fffAddcdD0d31",
+      "1",
+      "0x434Aa3FDb11798EDaB506D4a5e48F70845a66219",
+      "0x2aa3cBB35161F33b113c849349D345d1807738de",
+      "18",
+      "Spartan Council Pool Rewards"
+    ]*/
+
+    const args = [
+      //
+      poolId,
+      collateralType,
+      amount,
+      start,
+      duration,
+    ];
+    log({ poolId, collateralType, amount, start, duration });
+    const gasLimit = await RewardsDistributor.connect(signer)
+      .estimateGas.distributeRewards(...args)
+      .catch(parseError);
+    const tx = await RewardsDistributor.connect(signer)
+      .distributeRewards(...args, { gasLimit: gasLimit.mul(2) })
+      .catch(parseError);
+    await tx
+      .wait()
+      .then((txn) => log(txn.events) || txn, parseError)
+      .then(gasLog({ action: 'RewardsDistributor.distributeRewards', log }));
+
+    await provider.send('anvil_stopImpersonatingAccount', [poolOwner]);
+  });
+
+  it('should create user account', async () => {
+    assert.equal(
+      await getAccountOwner({ accountId }),
+      ethers.constants.AddressZero,
+      'New wallet should not have an account yet'
+    );
+    await createAccount({ wallet, accountId });
+    assert.equal(await getAccountOwner({ accountId }), address);
+  });
+
+  it('should set fUSDC balance to 10_000_000', async () => {
+    const { tokenAddress } = await getCollateralConfig('fUSDC');
+    assert.equal(
+      await getCollateralBalance({ address, symbol: 'fUSDC' }),
+      0,
+      'New wallet has 0 fUSDC balance'
+    );
+    await setMintableTokenBalance({ privateKey, tokenAddress, balance: 10_000_000 });
+    assert.equal(await getCollateralBalance({ address, symbol: 'fUSDC' }), 10_000_000);
+  });
+
+  it('should approve fUSDC spending for SpotMarket', async () => {
+    assert.equal(
+      await isCollateralApproved({
+        address,
+        symbol: 'fUSDC',
+        spenderAddress: require('../../deployments/SpotMarketProxy.json').address,
+      }),
+      false,
+      'New wallet has not allowed SpotMarket fUSDC spending'
+    );
+    await approveCollateral({
+      privateKey,
+      symbol: 'fUSDC',
+      spenderAddress: require('../../deployments/SpotMarketProxy.json').address,
+    });
+    assert.equal(
+      await isCollateralApproved({
+        address,
+        symbol: 'fUSDC',
+        spenderAddress: require('../../deployments/SpotMarketProxy.json').address,
+      }),
+      true
+    );
+  });
+
+  it('should increase max collateral for the test to 10_000_000', async () => {
+    await configureMaximumMarketCollateral({
+      marketId: require('../../deployments/extras.json').synth_usdc_market_id,
+      symbol: 'fUSDC',
+      targetAmount: String(10_000_000),
+    });
+    await setSpotWrapper({
+      marketId: require('../../deployments/extras.json').synth_usdc_market_id,
+      symbol: 'fUSDC',
+      targetAmount: String(10_000_000),
+    });
+  });
+
+  it('should wrap 5_000_000 fUSDC', async () => {
+    const balance = await wrapCollateral({ wallet, symbol: 'fUSDC', amount: 5_000_000 });
+    assert.equal(balance, 5_000_000);
+  });
+
+  it('should approve sUSDC spending for CoreProxy', async () => {
+    assert.equal(
+      await isCollateralApproved({
+        address,
+        symbol: 'sUSDC',
+        spenderAddress: require('../../deployments/CoreProxy.json').address,
+      }),
+      false,
+      'New wallet has not allowed CoreProxy sUSDC spending'
+    );
+    await approveCollateral({
+      privateKey,
+      symbol: 'sUSDC',
+      spenderAddress: require('../../deployments/CoreProxy.json').address,
+    });
+    assert.equal(
+      await isCollateralApproved({
+        address,
+        symbol: 'sUSDC',
+        spenderAddress: require('../../deployments/CoreProxy.json').address,
+      }),
+      true
+    );
+  });
+
+  it('should deposit 4_900_000 sUSDC into the system', async () => {
+    assert.equal(await getCollateralBalance({ address, symbol: 'sUSDC' }), 5_000_000);
+    assert.deepEqual(await getAccountCollateral({ accountId, symbol: 'sUSDC' }), {
+      totalDeposited: 0,
+      totalAssigned: 0,
+      totalLocked: 0,
+    });
+
+    await depositCollateral({ privateKey, symbol: 'sUSDC', accountId, amount: 4_900_000 });
+
+    assert.equal(await getCollateralBalance({ address, symbol: 'sUSDC' }), 100_000);
+    assert.deepEqual(await getAccountCollateral({ accountId, symbol: 'sUSDC' }), {
+      totalDeposited: 4_900_000,
+      totalAssigned: 0,
+      totalLocked: 0,
+    });
+  });
+
+  it('should make a price update', async () => {
+    // We must sync timestamp of the fork before making price updates
+    await syncTime();
+
+    // delegating collateral and views requiring price will fail if there's no price update within the last hour,
+    // so we send off a price update just to be safe
+    await doPriceUpdate({
+      wallet,
+      marketId: 100,
+      settlementStrategyId: require('../../deployments/extras.json').eth_pyth_settlement_strategy,
+    });
+    await doPriceUpdate({
+      wallet,
+      marketId: 200,
+      settlementStrategyId: require('../../deployments/extras.json').btc_pyth_settlement_strategy,
+    });
+  });
+
+  it('should delegate 4_800_000 sUSDC into the Spartan Council pool', async () => {
+    assert.deepEqual(await getAccountCollateral({ accountId, symbol: 'sUSDC' }), {
+      totalDeposited: 4_900_000,
+      totalAssigned: 0,
+      totalLocked: 0,
+    });
+    await delegateCollateral({
+      privateKey,
+      symbol: 'sUSDC',
+      accountId,
+      amount: 4_800_000,
+      poolId: 1,
+    });
+    assert.deepEqual(await getAccountCollateral({ accountId, symbol: 'sUSDC' }), {
+      totalDeposited: 4_900_000,
+      totalAssigned: 4_800_000,
+      totalLocked: 0,
+    });
+  });
+});

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -106,3 +106,14 @@ options.collateralType = "<%= extras.synth_usdc_token_address %>"
 options.payoutToken = "<%= imports.snx_mock_collateral.contracts.MintableToken.address %>"
 options.payoutTokenDecimals = "18"
 options.name = "Spartan Council Pool Rewards"
+
+[invoke.register_spartan_council_pool_rewards]
+target = ["system.CoreProxy"]
+fromCall.func = "getPoolOwner"
+fromCall.args = ["<%= settings.sc_pool_id %>"]
+func = "registerRewardsDistributor"
+args = [
+    "<%= settings.sc_pool_id %>",
+    "<%= extras.synth_usdc_token_address %>",
+    "<%= imports.spartan_council_pool_rewards.contracts.RewardsDistributor.address %>",
+]

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -97,7 +97,7 @@ args = [
 ]
 
 [provision.spartan_council_pool_rewards]
-source = "synthetix-rewards-distributor:0.0.1"
+source = "synthetix-rewards-distributor:0.0.2"
 targetPreset = "<%= settings.target_preset %>"
 options.salt = "<%= settings.salt %>"
 options.rewardManager = "<%= imports.system.contracts.CoreProxy.address %>"

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -95,3 +95,14 @@ args = [
         { marketId = "<%= imports.perpsFactory.extras.superMarketId %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1') %>" },
     ],
 ]
+
+[provision.spartan_council_pool_rewards]
+source = "synthetix-rewards-distributor:0.0.1"
+targetPreset = "<%= settings.target_preset %>"
+options.salt = "<%= settings.salt %>"
+options.rewardManager = "<%= imports.system.contracts.CoreProxy.address %>"
+options.poolId = "<%= settings.sc_pool_id %>"
+options.collateralType = "<%= extras.synth_usdc_token_address %>"
+options.payoutToken = "<%= imports.snx_mock_collateral.contracts.MintableToken.address %>"
+options.payoutTokenDecimals = "18"
+options.name = "Spartan Council Pool Rewards"


### PR DESCRIPTION
- [x] Provision synthetix-rewards-distributor
- [x] Add e2e test to distribute rewards
- [x] Add e2e test to claim rewards

Full test works well:
- user delegates  4_800_000 sUSDC
- pool owner distributes 1_000_000 fwSNX
- user claims rewards and gets ~236_065.6 fwSNX
- rewards distributor total rewards amount is reduced to 1_000_000 - 236_065 = ~763_934.4

<img width="1713" alt="_ 2024-03-05 at 12 41 44" src="https://github.com/Synthetixio/synthetix-deployments/assets/28145325/66c2d77b-b07d-44a7-b474-fbfa54a69ff3">

