### PR TITLE
increase `maxDebtShareValueD18` for all networks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,28 +484,12 @@ workflows:
           provider-url: https://sepolia.base.org
 
       - fork-test:
-          name: base-goerli-andromeda
-          toml: omnibus-base-goerli-andromeda.toml
-          package: "synthetix-omnibus:latest"
-          preset: "andromeda"
-          chain-id: 84531
-          provider-url: https://goerli.base.org
-
-      - fork-test:
           name: base-mainnet-andromeda
           toml: omnibus-base-mainnet-andromeda.toml
           package: "synthetix-omnibus:latest"
           preset: "andromeda"
           chain-id: 8453
           provider-url: https://mainnet.base.org
-
-      - fork-test:
-          name: base-goerli
-          toml: omnibus-base-goerli.toml
-          package: "synthetix-omnibus:latest"
-          preset: "main"
-          chain-id: 84531
-          provider-url: https://goerli.base.org
 
       - fork-test:
           name: goerli

--- a/omnibus-base-mainnet-andromeda.toml
+++ b/omnibus-base-mainnet-andromeda.toml
@@ -91,7 +91,7 @@ func = "setPoolConfiguration"
 args = [
     "<%= settings.sc_pool_id %>",
     [
-        { marketId = "<%= imports.perpsFactory.extras.superMarketId %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1') %>" },
+        { marketId = "<%= imports.perpsFactory.extras.superMarketId %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1000000000') %>" },
     ],
 ]
 

--- a/omnibus-base-mainnet.toml
+++ b/omnibus-base-mainnet.toml
@@ -111,7 +111,7 @@ func = "setPoolConfiguration"
 args = [
     "<%= settings.sc_pool_id %>",
     [
-        { marketId = "<%= extras.synth_eth_market_id %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1') %>" },
+        { marketId = "<%= extras.synth_eth_market_id %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1000000000') %>" },
     ],
 ]
 depends = ["invoke.createScPool", "invoke.createEthSynth"]

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -92,6 +92,6 @@ func = "setPoolConfiguration"
 args = [
     "<%= settings.sc_pool_id %>",
     [
-        { marketId = "<%= imports.perpsFactory.extras.superMarketId %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1') %>" },
+        { marketId = "<%= imports.perpsFactory.extras.superMarketId %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1000000000') %>" },
     ],
 ]

--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -109,7 +109,7 @@ func = "setPoolConfiguration"
 args = [
     "<%= settings.sc_pool_id %>",
     [
-        { marketId = "<%= extras.synth_eth_market_id %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1') %>" },
+        { marketId = "<%= extras.synth_eth_market_id %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1000000000') %>" },
     ],
 ]
 depends = ["invoke.createScPool", "invoke.createEthSynth"]


### PR DESCRIPTION
Increase the `maxDebtShareValueD18` setting, which will increase the credit capacity of the perps markets.