### PR TITLE
Cannon 2.11.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "@pythnetwork/pyth-evm-js": "^1.33.0",
-    "@usecannon/builder": "2.11.20",
-    "@usecannon/cli": "2.11.20",
+    "@usecannon/builder": "2.11.21",
+    "@usecannon/cli": "2.11.21",
     "debug": "^4.3.4",
     "ethers": "^5.7.2",
     "hardhat": "^2.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,9 +1189,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@usecannon/builder@npm:2.11.20":
-  version: 2.11.20
-  resolution: "@usecannon/builder@npm:2.11.20"
+"@usecannon/builder@npm:2.11.21":
+  version: 2.11.21
+  resolution: "@usecannon/builder@npm:2.11.21"
   dependencies:
     "@synthetixio/router": "npm:^3.3.7"
     axios: "npm:^1.6.7"
@@ -1206,17 +1206,17 @@ __metadata:
     typestub-ipfs-only-hash: "npm:^4.0.0"
     viem: "npm:^2.6.1"
     zod: "npm:^3.22.4"
-  checksum: 10/415031198b8b7db5ca58bc33983fc8cf5f8ebc8d6aea86ffba4ba0bce11a966c2ceab1c379073304665d4513ac6cac9ed88ba963771d8aa60b4548a2f7ce0be6
+  checksum: 10/955c53e945bcde59b4a9db96de55336307d6c12a1be58e256a05075d6039444f4c3f30e8836c6a7a4b3efb958f938f1a525cb9843ba66f9123b540abca309e9d
   languageName: node
   linkType: hard
 
-"@usecannon/cli@npm:2.11.20":
-  version: 2.11.20
-  resolution: "@usecannon/cli@npm:2.11.20"
+"@usecannon/cli@npm:2.11.21":
+  version: 2.11.21
+  resolution: "@usecannon/cli@npm:2.11.21"
   dependencies:
     "@iarna/toml": "npm:^3.0.0"
     "@synthetixio/wei": "npm:^2.74.1"
-    "@usecannon/builder": "npm:2.11.20"
+    "@usecannon/builder": "npm:2.11.21"
     abitype: "npm:^1.0.0"
     chalk: "npm:^4.1.2"
     commander: "npm:^9.5.0"
@@ -1236,7 +1236,7 @@ __metadata:
     zod: "npm:^3.22.4"
   bin:
     cannon: bin/cannon.js
-  checksum: 10/89094621f985f530e44e966b8c2cd3e92db09400d300318c9fcad9df4a50185067229c6e452e0cb2abaa928fba4993185654d72b3aacde9efc2e975b51c391fa
+  checksum: 10/d7011f0f0c22eff8b81e5e9c9bd2f3e131a31c96e17c428c31cb41dd85cc04ea2862fdd1ef43780a31bde430cc0e997bb0f10c4fb4db8dea04633508b682e214
   languageName: node
   linkType: hard
 
@@ -4717,8 +4717,8 @@ __metadata:
   resolution: "synthetix-deployments@workspace:."
   dependencies:
     "@pythnetwork/pyth-evm-js": "npm:^1.33.0"
-    "@usecannon/builder": "npm:2.11.20"
-    "@usecannon/cli": "npm:2.11.20"
+    "@usecannon/builder": "npm:2.11.21"
+    "@usecannon/cli": "npm:2.11.21"
     debug: "npm:^4.3.4"
     ethers: "npm:^5.7.2"
     hardhat: "npm:^2.21.0"


### PR DESCRIPTION
```
   @pythnetwork/pyth-evm-js -------------------- ◉ ^1.33.0 ------ ◯ ^1.35.0 ------
   @usecannon/builder -------------------------- ◯ 2.11.20 ------ ◉ 2.11.21 ------
   @usecannon/cli ------------------------------ ◯ 2.11.20 ------ ◉ 2.11.21 ------
   ethers -------------------------------------- ◉ ^5.7.2 -------                  ◯ ^6.11.1 ------
   hardhat ------------------------------------- ◉ ^2.21.0 ------ ◯ ^2.22.1 ------
   solc ---------------------------------------- ◉ 0.8.21 ------- ◯ 0.8.25 -------
   supports-color ------------------------------ ◉ ^8.1.1 -------                  ◯ ^9.4.0 -------
```