### PR TITLE
Idempotent Setters Only

### DIFF
--- a/e2e/tests/omnibus-base-sepolia-andromeda.toml/Rewards.e2e.js
+++ b/e2e/tests/omnibus-base-sepolia-andromeda.toml/Rewards.e2e.js
@@ -280,8 +280,10 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     });
 
     assert.equal(
-      await getTokenBalance({ walletAddress: distributorAddress, tokenAddress: payoutToken }),
-      initialBalance + 1_000_000,
+      Math.floor(
+        await getTokenBalance({ walletAddress: distributorAddress, tokenAddress: payoutToken })
+      ),
+      Math.floor(initialBalance + 1_000_000),
       'Rewards Distributor has 1_000_000 fwSNX balance'
     );
   });
@@ -348,8 +350,8 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     assert.ok(postClaimBalance > 0, 'Wallet has some non-zero fwSNX balance AFTER claim');
 
     assert.equal(
-      await getTokenRewardsDistributorRewardsAmount({ distributorAddress }),
-      1_000_000 - postClaimBalance,
+      Math.floor(await getTokenRewardsDistributorRewardsAmount({ distributorAddress })),
+      Math.floor(1_000_000 - postClaimBalance),
       'should deduct claimed token amount from total distributor rewards amount'
     );
   });

--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -17,13 +17,13 @@ include = [
 ]
 
 [setting.snx_package]
-defaultValue = "synthetix:3.3.4"
+defaultValue = "synthetix:3.3.5"
 
 [setting.spot_market_package]
-defaultValue = "synthetix-spot-market:3.3.4"
+defaultValue = "synthetix-spot-market:3.3.5"
 
 [setting.perps_market_package]
-defaultValue = "synthetix-perps-market:3.3.4"
+defaultValue = "synthetix-perps-market:3.3.5"
 
 [setting.owner]
 defaultValue = "0x6E1613B5c68B4Cf2A58400D8019a97849A678139"

--- a/tomls/markets/perps/btc.toml
+++ b/tomls/markets/perps/btc.toml
@@ -44,25 +44,13 @@ args = [
     "<%= settings.bigCapStrictStalenessTolerance %>",
 ]
 
-# DO NOT MODIFY THIS STEP!. Edit [invoke.setPerpsBtcSettlementStrategy] instead.
-[invoke.addPerpsBtcSettlementStrategy]
-target = ["perpsFactory.PerpsMarketProxy"]
-fromCall.func = "owner"
-func = "addSettlementStrategy"
-args = [
-    "<%= settings.btcPerpsMarketId %>",
-    { strategyType = "0", settlementDelay = "0", settlementWindowDuration = "1", priceVerificationContract = "0x0000000000000000000000000000000000000000", feedId = "0x0000000000000000000000000000000000000000000000000000000000000000", settlementReward = "0", disabled = false, commitmentPriceDelay = "0" },
-]
-extra.btc_pyth_settlement_strategy.event = "SettlementStrategyAdded"
-extra.btc_pyth_settlement_strategy.arg = 2
-
 [invoke.setPerpsBtcSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.btcPerpsMarketId %>",
-    "<%= extras.btc_pyth_settlement_strategy %>",                                                                                                                                                                                                                                                                                                                                                                                                                         # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                         # Settlement Strategy ID
     { strategyType = "0", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythBtcFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/perps/btc.toml
+++ b/tomls/markets/perps/btc.toml
@@ -50,7 +50,7 @@ fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.btcPerpsMarketId %>",
-    "0",                                                                                                                                                                                                                                                                                                                                                                                                                         # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                                                                  # Settlement Strategy ID
     { strategyType = "0", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythBtcFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/perps/eth.toml
+++ b/tomls/markets/perps/eth.toml
@@ -57,7 +57,7 @@ fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.ethPerpsMarketId %>",
-    "0",                                                                                                                                                                                                                                                                                                                                                                                                                         # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                                                                  # Settlement Strategy ID
     { strategyType = "0", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythEthFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/perps/eth.toml
+++ b/tomls/markets/perps/eth.toml
@@ -51,25 +51,13 @@ args = [
     "<%= settings.bigCapStrictStalenessTolerance %>",
 ]
 
-# Do not modify this step. Edit [invoke.setPerpsEthSettlementStrategy] instead.
-[invoke.addPerpsEthSettlementStrategy]
-target = ["perpsFactory.PerpsMarketProxy"]
-fromCall.func = "owner"
-func = "addSettlementStrategy"
-args = [
-    "<%= settings.ethPerpsMarketId %>",
-    { strategyType = "0", settlementDelay = "0", settlementWindowDuration = "1", priceVerificationContract = "0x0000000000000000000000000000000000000000", feedId = "0x0000000000000000000000000000000000000000000000000000000000000000", settlementReward = "0", disabled = false, commitmentPriceDelay = "0" },
-]
-extra.eth_pyth_settlement_strategy.event = "SettlementStrategyAdded"
-extra.eth_pyth_settlement_strategy.arg = 2
-
 [invoke.setPerpsEthSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.ethPerpsMarketId %>",
-    "<%= extras.eth_pyth_settlement_strategy %>",                                                                                                                                                                                                                                                                                                                                                                                                                         # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                         # Settlement Strategy ID
     { strategyType = "0", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythEthFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/perps/link.toml
+++ b/tomls/markets/perps/link.toml
@@ -44,25 +44,13 @@ args = [
     "<%= settings.bigCapStrictStalenessTolerance %>",
 ]
 
-# Do not modify this step. Edit [invoke.setPerpsLinkSettlementStrategy] instead.
-[invoke.addPerpsLinkSettlementStrategy]
-target = ["perpsFactory.PerpsMarketProxy"]
-fromCall.func = "owner"
-func = "addSettlementStrategy"
-args = [
-    "<%= settings.linkPerpsMarketId %>",
-    { strategyType = "0", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythLinkFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
-]
-extra.link_pyth_settlement_strategy.event = "SettlementStrategyAdded"
-extra.link_pyth_settlement_strategy.arg = 2
-
 [invoke.setPerpsLinkSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.linkPerpsMarketId %>",
-    "<%= extras.link_pyth_settlement_strategy %>",                                                                                                                                                                                                                                                                                                                                                                                                                         # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                         # Settlement Strategy ID
     { strategyType = "0", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythLinkFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/perps/link.toml
+++ b/tomls/markets/perps/link.toml
@@ -50,7 +50,7 @@ fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.linkPerpsMarketId %>",
-    "0",                                                                                                                                                                                                                                                                                                                                                                                                                         # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                                                                   # Settlement Strategy ID
     { strategyType = "0", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythLinkFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/perps/op.toml
+++ b/tomls/markets/perps/op.toml
@@ -59,7 +59,7 @@ fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.opPerpsMarketId %>",
-    "0",                                                                                                                                                                                                                                                                                                                                                                                                                                                    # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            # Settlement Strategy ID
     { strategyType = "<%= settings.strategyType %>", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythOpFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/perps/op.toml
+++ b/tomls/markets/perps/op.toml
@@ -53,25 +53,13 @@ args = [
     "<%= settings.bigCapStrictStalenessTolerance %>",
 ]
 
-# Do not modify this step. Edit [invoke.setPerpsOpSettlementStrategy] instead.
-[invoke.addPerpsOpSettlementStrategy]
-target = ["perpsFactory.PerpsMarketProxy"]
-fromCall.func = "owner"
-func = "addSettlementStrategy"
-args = [
-    "<%= settings.opPerpsMarketId %>",
-    { strategyType = "<%= settings.strategyType %>", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythOpFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
-]
-extra.op_pyth_settlement_strategy.event = "SettlementStrategyAdded"
-extra.op_pyth_settlement_strategy.arg = 2
-
 [invoke.setPerpsOpSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.opPerpsMarketId %>",
-    "<%= extras.op_pyth_settlement_strategy %>",                                                                                                                                                                                                                                                                                                                                                                                                                                                    # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                                                    # Settlement Strategy ID
     { strategyType = "<%= settings.strategyType %>", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythOpFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/perps/snx.toml
+++ b/tomls/markets/perps/snx.toml
@@ -59,7 +59,7 @@ fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.snxPerpsMarketId %>",
-    "0",                                                                                                                                                                                                                                                                                                                                                                                                                                                    # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             # Settlement Strategy ID
     { strategyType = "<%= settings.strategyType %>", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythSnxFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/perps/snx.toml
+++ b/tomls/markets/perps/snx.toml
@@ -53,25 +53,13 @@ args = [
     "<%= settings.bigCapStrictStalenessTolerance %>",
 ]
 
-# Do not modify this step. Edit [invoke.setPerpsSnxSettlementStrategy] instead.
-[invoke.addPerpsSnxSettlementStrategy]
-target = ["perpsFactory.PerpsMarketProxy"]
-fromCall.func = "owner"
-func = "addSettlementStrategy"
-args = [
-    "<%= settings.snxPerpsMarketId %>",
-    { strategyType = "<%= settings.strategyType %>", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythSnxFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
-]
-extra.snx_pyth_settlement_strategy.event = "SettlementStrategyAdded"
-extra.snx_pyth_settlement_strategy.arg = 2
-
 [invoke.setPerpsSnxSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.snxPerpsMarketId %>",
-    "<%= extras.xrp_pyth_settlement_strategy %>",                                                                                                                                                                                                                                                                                                                                                                                                                                                    # Settlement Strategy ID
+    "0",                                                                                                                                                                                                                                                                                                                                                                                                                                                    # Settlement Strategy ID
     { strategyType = "<%= settings.strategyType %>", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pythSnxFeedId %>", settlementReward = "<%= parseEther(settings.settlementReward) %>", disabled = false, commitmentPriceDelay = "<%= settings.commitmentPriceDelay %>" },
 ]
 

--- a/tomls/markets/spot/btc.toml
+++ b/tomls/markets/spot/btc.toml
@@ -21,18 +21,6 @@ args = [
     "<%= extras.btc_oracle_id %>",
 ]
 
-[invoke.addSynthSettlementStrategyBtc]
-target = ["spotFactory.SpotMarketProxy"]
-fromCall.func = "getMarketOwner"
-fromCall.args = ["<%= extras.synth_btc_market_id %>"]
-func = "addSettlementStrategy"
-args = [
-    "<%= extras.synth_btc_market_id %>",
-    { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythBtcFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
-]
-extra.synth_btc_settlement_strategy.event = "SettlementStrategyAdded"
-extra.synth_btc_settlement_strategy.arg = 1
-
 [invoke.setSynthSettlementStrategyBtc]
 target = ["spotFactory.SpotMarketProxy"]
 fromCall.func = "getMarketOwner"
@@ -40,7 +28,7 @@ fromCall.args = ["<%= extras.synth_btc_market_id %>"]
 func = "setSettlementStrategy"
 args = [
     "<%= extras.synth_btc_market_id %>",
-    "<%= extras.synth_btc_settlement_strategy %>",
+    "0",
     { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythBtcFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
 ]
 

--- a/tomls/markets/spot/eth.toml
+++ b/tomls/markets/spot/eth.toml
@@ -54,7 +54,7 @@ func = "setSettlementStrategy"
 args = [
     "<%= extras.synth_eth_market_id %>",
     "0",
-    { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythEthFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false }
+    { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythEthFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
 ]
 
 [invoke.setSynthAsyncFixedFeeEth]

--- a/tomls/markets/spot/eth.toml
+++ b/tomls/markets/spot/eth.toml
@@ -46,29 +46,16 @@ fromCall.args = ["<%= extras.synth_eth_market_id %>"]
 func = "setAtomicFixedFee"
 args = ["<%= extras.synth_eth_market_id %>", "<%= MaxUint256 %>"]
 
-[invoke.addSynthSettlementStrategyEth]
+[invoke.setSynthSettlementStrategyEth]
 target = ["spotFactory.SpotMarketProxy"]
 fromCall.func = "getMarketOwner"
 fromCall.args = ["<%= extras.synth_eth_market_id %>"]
-func = "addSettlementStrategy"
+func = "setSettlementStrategy"
 args = [
     "<%= extras.synth_eth_market_id %>",
-    # strategyType = 1 (pyth)
-    { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythEthFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
+    "0",
+    { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythEthFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false }
 ]
-extra.synth_eth_settlement_strategy.event = "SettlementStrategyAdded"
-extra.synth_eth_settlement_strategy.arg = 1
-
-# [invoke.setSynthSettlementStrategyEth]
-# target = ["spotFactory.SpotMarketProxy"]
-# fromCall.func = "getMarketOwner"
-# fromCall.args = ["<%= extras.synth_eth_market_id %>"]
-# func = "setSettlementStrategy"
-# args = [
-#     "<%= extras.synth_eth_market_id %>",
-#     "<%= extras.synth_eth_settlement_strategy %>",
-#     { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythEthFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false }
-# ]
 
 [invoke.setSynthAsyncFixedFeeEth]
 target = ["spotFactory.SpotMarketProxy"]

--- a/tomls/markets/spot/link.toml
+++ b/tomls/markets/spot/link.toml
@@ -25,18 +25,6 @@ args = [
     "<%= extras.link_oracle_id %>",
 ]
 
-[invoke.addSynthSettlementStrategyLink]
-target = ["spotFactory.SpotMarketProxy"]
-fromCall.func = "getMarketOwner"
-fromCall.args = ["<%= extras.synth_link_market_id %>"]
-func = "addSettlementStrategy"
-args = [
-    "<%= extras.synth_link_market_id %>",
-    { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythLinkFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
-]
-extra.synth_link_settlement_strategy.event = "SettlementStrategyAdded"
-extra.synth_link_settlement_strategy.arg = 1
-
 [invoke.setSynthSettlementStrategyLink]
 target = ["spotFactory.SpotMarketProxy"]
 fromCall.func = "getMarketOwner"
@@ -44,7 +32,7 @@ fromCall.args = ["<%= extras.synth_link_market_id %>"]
 func = "setSettlementStrategy"
 args = [
     "<%= extras.synth_link_market_id %>",
-    "<%= extras.synth_link_settlement_strategy %>",
+    "0",
     { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythLinkFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
 ]
 

--- a/tomls/markets/spot/op.toml
+++ b/tomls/markets/spot/op.toml
@@ -25,18 +25,6 @@ args = [
     "<%= extras.op_oracle_id %>",
 ]
 
-[invoke.addSynthSettlementStrategyOp]
-target = ["spotFactory.SpotMarketProxy"]
-fromCall.func = "getMarketOwner"
-fromCall.args = ["<%= extras.synth_op_market_id %>"]
-func = "addSettlementStrategy"
-args = [
-    "<%= extras.synth_op_market_id %>",
-    { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythOpFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
-]
-extra.synth_op_settlement_strategy.event = "SettlementStrategyAdded"
-extra.synth_op_settlement_strategy.arg = 1
-
 [invoke.setSynthSettlementStrategyOp]
 target = ["spotFactory.SpotMarketProxy"]
 fromCall.func = "getMarketOwner"
@@ -44,7 +32,7 @@ fromCall.args = ["<%= extras.synth_op_market_id %>"]
 func = "setSettlementStrategy"
 args = [
     "<%= extras.synth_op_market_id %>",
-    "<%= extras.synth_op_settlement_strategy %>",
+    "0",
     { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythOpFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
 ]
 

--- a/tomls/markets/spot/snx.toml
+++ b/tomls/markets/spot/snx.toml
@@ -25,18 +25,6 @@ args = [
     "<%= extras.snx_oracle_id %>",
 ]
 
-[invoke.addSynthSettlementStrategySnx]
-target = ["spotFactory.SpotMarketProxy"]
-fromCall.func = "getMarketOwner"
-fromCall.args = ["<%= extras.synth_snx_market_id %>"]
-func = "addSettlementStrategy"
-args = [
-    "<%= extras.synth_snx_market_id %>",
-    { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythSnxFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
-]
-extra.synth_snx_settlement_strategy.event = "SettlementStrategyAdded"
-extra.synth_snx_settlement_strategy.arg = 1
-
 [invoke.setSynthSettlementStrategySnx]
 target = ["spotFactory.SpotMarketProxy"]
 fromCall.func = "getMarketOwner"
@@ -44,7 +32,7 @@ fromCall.args = ["<%= extras.synth_snx_market_id %>"]
 func = "setSettlementStrategy"
 args = [
     "<%= extras.synth_snx_market_id %>",
-    "<%= extras.synth_snx_settlement_strategy %>",
+    "0",
     { strategyType = "1", settlementDelay = "<%= settings.bigCapSettlementDelay %>", settlementWindowDuration = "<%= settings.bigCapSettlementWindowDuration %>", priceVerificationContract = "<%= settings.pythPriceVerificationAddress %>", feedId = "<%= settings.pythSnxFeedId %>", url = "<%= settings.pythFeedUrl %>", settlementReward = 0, minimumUsdExchangeAmount = "<%= parseEther(settings.settlementMinimumUsdExchangeAmount) %>", maxRoundingLoss = "<%= parseEther(settings.settlementMaxRoundingLoss) %>", priceDeviationTolerance = "<%= parseEther('1') %>", disabled = false },
 ]
 


### PR DESCRIPTION
AFAIK, all markets only have 1 settlement strategy, which means its been assigned to ID `0`.

We should be able to remove the "add" steps and hardcode this ID, such that updated settings files don't trigger new settlement strategies to be added.

Strategies can be added in the future by adding a new "set" step with ID 1, 2 ,3, etc.