### PR TITLE
SCCP-312: Increase Base ETH and BTC OI limits to $20m

### DIFF
--- a/e2e/tests/omnibus-base-mainnet-andromeda.toml/Perps_BTC.e2e.js
+++ b/e2e/tests/omnibus-base-mainnet-andromeda.toml/Perps_BTC.e2e.js
@@ -73,12 +73,12 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     assert.equal(market.marketId, marketId);
   });
 
-  it('should have max open interest 22 BTC', async () => {
+  it('should have max open interest 149 BTC', async () => {
     const maxOpenInterest = parseFloat(
       ethers.utils.formatEther(await PerpsMarketProxy.maxOpenInterest(marketId))
     );
     log({ maxOpenInterest });
-    assert.equal(maxOpenInterest, 22);
+    assert.equal(maxOpenInterest, 149);
   });
 
   it('should make a price update', async () => {
@@ -143,10 +143,10 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     assert.equal(Number(ethers.utils.formatEther(maxFundingVelocity)), 9, 'maxFundingVelocity');
   });
 
-  it('should have 22 BTC Max Market Size', async () => {
+  it('should have 149 BTC Max Market Size', async () => {
     const maxSize = await PerpsMarketProxy.getMaxMarketSize(marketId);
 
-    assert.equal(ethers.utils.formatEther(maxSize), 22);
+    assert.equal(ethers.utils.formatEther(maxSize), 149);
   });
 
   it('should have 0.0002 Maker fee, 0.0005 Taker fee', async () => {

--- a/e2e/tests/omnibus-base-mainnet-andromeda.toml/Perps_ETH.e2e.js
+++ b/e2e/tests/omnibus-base-mainnet-andromeda.toml/Perps_ETH.e2e.js
@@ -73,12 +73,12 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     assert.equal(market.marketId, marketId);
   });
 
-  it('should have max open interest 385 ETH', async () => {
+  it('should have max open interest 2777 ETH', async () => {
     const maxOpenInterest = parseFloat(
       ethers.utils.formatEther(await PerpsMarketProxy.maxOpenInterest(marketId))
     );
     log({ maxOpenInterest });
-    assert.equal(maxOpenInterest, 385);
+    assert.equal(maxOpenInterest, 2777);
   });
 
   it('should make a price update', async () => {
@@ -143,10 +143,10 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     assert.equal(Number(ethers.utils.formatEther(maxFundingVelocity)), 9, 'maxFundingVelocity');
   });
 
-  it('should have 385 ETH Max Market Size', async () => {
+  it('should have 2777 ETH Max Market Size', async () => {
     const maxSize = await PerpsMarketProxy.getMaxMarketSize(marketId);
 
-    assert.equal(ethers.utils.formatEther(maxSize), 385);
+    assert.equal(ethers.utils.formatEther(maxSize), 2777);
   });
 
   it('should have 0.0002 Maker fee, 0.0005 Taker fee', async () => {

--- a/e2e/tests/omnibus-base-mainnet-andromeda.toml/Perps_Trading.e2e.js
+++ b/e2e/tests/omnibus-base-mainnet-andromeda.toml/Perps_Trading.e2e.js
@@ -80,14 +80,14 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     assert.equal(await getEthBalance({ address }), 100);
   });
 
-  it('should set USDC balance to 100_000', async () => {
+  it('should set USDC balance to 10_000_000', async () => {
     assert.equal(
       await getCollateralBalance({ address, symbol: 'USDC' }),
       0,
       'New wallet has 0 USDC balance'
     );
-    await setUSDCTokenBalance({ wallet, balance: 100_000 });
-    assert.equal(await getCollateralBalance({ address, symbol: 'USDC' }), 100_000);
+    await setUSDCTokenBalance({ wallet, balance: 10_000_000 });
+    assert.equal(await getCollateralBalance({ address, symbol: 'USDC' }), 10_000_000);
   });
 
   it('should approve USDC spending for SpotMarket', async () => {
@@ -166,9 +166,9 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     });
   });
 
-  it('should wrap 10_000 USDC', async () => {
-    const balance = await wrapCollateral({ wallet, symbol: 'USDC', amount: 10_000 });
-    assert.equal(balance, 10_000);
+  it('should wrap 1_000_000 USDC', async () => {
+    const balance = await wrapCollateral({ wallet, symbol: 'USDC', amount: 1_000_000 });
+    assert.equal(balance, 1_000_000);
   });
 
   it('should create perps account', async () => {
@@ -184,14 +184,14 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     assert.equal(permissions.length, 0);
   });
 
-  it('should atomic swap 5_000 sUSDC to snxUSD to trade', async () => {
+  it('should atomic swap 1_000_000 sUSDC to snxUSD to trade', async () => {
     assert.equal(await getCollateralBalance({ address, symbol: 'snxUSD' }), 0);
     await swapToSusd({
       wallet,
       marketId: require('../../deployments/extras.json').synth_usdc_market_id,
-      amount: 5_000,
+      amount: 1_000_000,
     });
-    assert.equal(await getCollateralBalance({ address, symbol: 'snxUSD' }), 5_000);
+    assert.equal(await getCollateralBalance({ address, symbol: 'snxUSD' }), 1_000_000);
   });
 
   it('should approve snxUSD spending for PerpsMarketProxy', async () => {
@@ -219,16 +219,16 @@ describe(require('path').basename(__filename, '.e2e.js'), function () {
     );
   });
 
-  it('should deposit 5_000 snxUSD to Perps', async () => {
+  it('should deposit 1_000_000 snxUSD to Perps', async () => {
     assert.equal(await getPerpsCollateral({ accountId }), 0);
-    await modifyPerpsCollateral({ wallet, accountId, deltaAmount: 5_000 });
-    assert.equal(await getPerpsCollateral({ accountId }), 5_000);
+    await modifyPerpsCollateral({ wallet, accountId, deltaAmount: 1_000_000 });
+    assert.equal(await getPerpsCollateral({ accountId }), 1_000_000);
   });
 
   it('should withdraw 100 snxUSD from Perps', async () => {
-    assert.equal(await getPerpsCollateral({ accountId }), 5_000);
+    assert.equal(await getPerpsCollateral({ accountId }), 1_000_000);
     await modifyPerpsCollateral({ wallet, accountId, deltaAmount: -100 });
-    assert.equal(await getPerpsCollateral({ accountId }), 4_900);
+    assert.equal(await getPerpsCollateral({ accountId }), 999_900);
   });
 
   it('should open a short 0.01 BTC position', async () => {

--- a/omnibus-base-mainnet-andromeda.toml
+++ b/omnibus-base-mainnet-andromeda.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "15"
+version = "16"
 description = "Andromeda deployment"
 preset = "andromeda"
 include = [

--- a/tomls/omnibus-base-mainnet-andromeda/perps/btc.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/btc.toml
@@ -17,7 +17,7 @@ defaultValue = "0.0002"
 defaultValue = "0.0005"
 
 [setting.perpsBtcMaxMarketSize]
-defaultValue = "22" #approx $1m
+defaultValue = "149" #approx $10m
 
 [setting.perpsBtcMaxMarketValue]
 defaultValue = "0" # not enabled

--- a/tomls/omnibus-base-mainnet-andromeda/perps/eth.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/eth.toml
@@ -17,7 +17,7 @@ defaultValue = "0.0002"
 defaultValue = "0.0005"
 
 [setting.perpsEthMaxMarketSize]
-defaultValue = "385" # approx $1m
+defaultValue = "2777" # approx $10m
 
 [setting.perpsEthMaxMarketValue]
 defaultValue = "0" # not enabled


### PR DESCRIPTION
- [SCCP-312: Increase Base ETH and BTC OI limits to $20m](https://sips.synthetix.io/sccp/sccp-312/)
- Updated tests
- Bumped version

UPD: as we want to maintain LP/OI 1/2 proportion we should get #183 or #184 + wait first