### PR TITLE
Remove SCPool support to 2nd supermarket and revoke permits (1/2)

### DIFF
--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -15,7 +15,7 @@ include = [
     "tomls/omnibus-base-sepolia-andromeda/spot/usdc.toml",          # sUSDC spot market/wrapper, mock for USDC
     "tomls/omnibus-base-sepolia-andromeda/spot/statausdc.toml",     # sStataUSDC spot market/wrapper, mock for aUSDC/stataUSDC from erc-4626-to-assets-ratio-oracle
     "tomls/permit-all-perps-perpsHighcapSystem.toml",               # Enable perps market
-    "tomls/revoke-permit-all-perps-perpsLowcapSystem.toml",         # Enable perps market
+    "tomls/permit-revoke-all-perps-perpsLowcapSystem.toml",         # Enable perps market
     "tomls/omnibus-base-sepolia-andromeda/perps/referrers.toml",
     "tomls/omnibus-base-sepolia-andromeda/perps/global.toml",       # Global perps settings
     "tomls/oracles/perps-keeper-cost.toml",                         # Add gas oracle for keeper fees

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "34"
+version = "35"
 description = "Andromeda dev deployment"
 preset = "andromeda"
 include = [
@@ -15,7 +15,7 @@ include = [
     "tomls/omnibus-base-sepolia-andromeda/spot/usdc.toml",          # sUSDC spot market/wrapper, mock for USDC
     "tomls/omnibus-base-sepolia-andromeda/spot/statausdc.toml",     # sStataUSDC spot market/wrapper, mock for aUSDC/stataUSDC from erc-4626-to-assets-ratio-oracle
     "tomls/permit-all-perps-perpsHighcapSystem.toml",               # Enable perps market
-    "tomls/permit-all-perps-perpsLowcapSystem.toml",                # Enable perps market
+    "tomls/revoke-permit-all-perps-perpsLowcapSystem.toml",         # Enable perps market
     "tomls/omnibus-base-sepolia-andromeda/perps/referrers.toml",
     "tomls/omnibus-base-sepolia-andromeda/perps/global.toml",       # Global perps settings
     "tomls/oracles/perps-keeper-cost.toml",                         # Add gas oracle for keeper fees
@@ -382,8 +382,7 @@ func = "setPoolConfiguration"
 args = [
     "<%= settings.sc_pool_id %>",
     [
-        { marketId = "<%= imports.perpsFactory.extras.superMarketId %>", weightD18 = 95, maxDebtShareValueD18 = "<%= parseEther('1') %>" },
-        { marketId = "<%= imports.perpsLowCapFactory.extras.superMarketId %>", weightD18 = 5, maxDebtShareValueD18 = "<%= parseEther('1') %>" },
+        { marketId = "<%= imports.perpsFactory.extras.superMarketId %>", weightD18 = 1, maxDebtShareValueD18 = "<%= parseEther('1') %>" },
     ],
 ]
 

--- a/tomls/permit-revoke-all-perps-perpsLowcapSystem.toml
+++ b/tomls/permit-revoke-all-perps-perpsLowcapSystem.toml
@@ -1,5 +1,5 @@
-[invoke.allowAllPerpsLowCapSystem]
+[invoke.revokeAllPerpsLowCapSystem]
 target = ["perpsLowCapFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setFeatureFlagAllowAll"
-args = ["<%= formatBytes32String('perpsSystem') %>", true]
+args = ["<%= formatBytes32String('perpsSystem') %>", false]


### PR DESCRIPTION
This is the first PR of two to move all new markets to the old good supermarket and not use a 2nd one.

In this step the 2nd supermarket is removed from SC Pool and the permits revoked, the next PR will change all the markets to use the main supermarket as proxy (add the markets to HighCap supermarket). 

Notice that the LowCap supermarket will still be around, but without any pool support or permissions so should be useless.

