### PR TITLE
Fix parseEthers usage on arb sepolia

### DIFF
--- a/tomls/omnibus-arbitrum-sepolia/perps/collaterals/usd.toml
+++ b/tomls/omnibus-arbitrum-sepolia/perps/collaterals/usd.toml
@@ -1,5 +1,17 @@
+[var.perps_collateral_USD_settings]
+usd_max_collateral_amount = "<%= MaxUint256 %>"
+usd_upper_limit_discount = "0"
+usd_lower_limit_discount = "0"
+usd_discount_scalar = "0"
+
 [invoke.setPerpsMaxCollateralForSnxUsd]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setCollateralConfiguration"
-args = ["0", "<%= MaxUint256 %>", "0", "0", "0"]
+args = [
+    "0",
+    "<%= settings.usd_max_collateral_amount %>",
+    "<%= settings.usd_upper_limit_discount %>",
+    "<%= settings.usd_lower_limit_discount %>",
+    "<%= settings.usd_discount_scalar %>",
+]

--- a/tomls/omnibus-arbitrum-sepolia/perps/global.toml
+++ b/tomls/omnibus-arbitrum-sepolia/perps/global.toml
@@ -1,12 +1,12 @@
 [var.perps_global_settings]
-perps_liquidation_min_keeper_reward_usd = "1"
-perps_liquidation_min_keeper_profit_ratio_d18 = "0.30"
-perps_liquidation_max_keeper_reward_usd = "30"
-perps_liquidation_max_keeper_scaling_ratio_d18 = "0.0003"
-perps_low_util_gradient = "0"
-perps_gradient_breakpoint = "0"
-perps_high_util_gradient = "0"
-perps_collateral_liquidation_ratio = "0.0003"
+perps_liquidation_min_keeper_reward_usd = "<%= parseEther('1') %>"
+perps_liquidation_min_keeper_profit_ratio_d18 = "<%= parseEther('0.30') %>"
+perps_liquidation_max_keeper_reward_usd = "<%= parseEther('30') %>"
+perps_liquidation_max_keeper_scaling_ratio_d18 = "<%= parseEther('0.0003') %>"
+perps_low_util_gradient = "<%= parseEther('0') %>"
+perps_gradient_breakpoint = "<%= parseEther('0') %>"
+perps_high_util_gradient = "<%= parseEther('0') %>"
+perps_collateral_liquidation_ratio = "<%= parseEther('0.0003') %>"
 perps_max_positions_per_account = "10"
 perps_max_collaterals_per_account = "3"
 
@@ -15,12 +15,11 @@ target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setKeeperRewardGuards"
 args = [
-    "<%= parseEther(settings.perps_liquidation_min_keeper_reward_usd) %>",
-    "<%= parseEther(settings.perps_liquidation_min_keeper_profit_ratio_d18) %>",
-    "<%= parseEther(settings.perps_liquidation_max_keeper_reward_usd) %>",
-    "<%= parseEther(settings.perps_liquidation_max_keeper_scaling_ratio_d18) %>",
+    "<%= settings.perps_liquidation_min_keeper_reward_usd %>",
+    "<%= settings.perps_liquidation_min_keeper_profit_ratio_d18 %>",
+    "<%= settings.perps_liquidation_max_keeper_reward_usd %>",
+    "<%= settings.perps_liquidation_max_keeper_scaling_ratio_d18 %>",
 ]
-depends = ['provision.perpsFactory', 'var.perps_global_settings']
 
 [invoke.setPerAccountCapsPerps]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -42,15 +41,13 @@ target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setInterestRateParameters"
 args = [
-    "<%= parseEther(settings.perps_low_util_gradient) %>",
-    "<%= parseEther(settings.perps_gradient_breakpoint) %>",
-    "<%= parseEther(settings.perps_high_util_gradient) %>",
+    "<%= settings.perps_low_util_gradient %>",
+    "<%= settings.perps_gradient_breakpoint %>",
+    "<%= settings.perps_high_util_gradient %>",
 ]
-depends = ['provision.perpsFactory', 'var.perps_global_settings']
 
 [invoke.PerpsMarketProxy_setCollateralLiquidationRatio_btc]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setCollateralLiquidateRewardRatio"
-args = ["<%= parseEther(settings.perps_collateral_liquidation_ratio) %>"]
-depends = ['var.perps_global_settings']
+args = ["<%= settings.perps_collateral_liquidation_ratio %>"]

--- a/tomls/omnibus-arbitrum-sepolia/perps/markets/btc.toml
+++ b/tomls/omnibus-arbitrum-sepolia/perps/markets/btc.toml
@@ -1,20 +1,20 @@
 [var.perps_btc_market_settings]
 btc_perps_market_id = "200"
-btc_perps_market_skew_scale = "<%= String(35_000) %>"
-btc_perps_market_max_funding_velocity = "9"
-btc_perps_maker_fee_ratio = "0"
-btc_perps_taker_fee_ratio = "0.0005"
-btc_perps_max_market_size = "1200"
-btc_perps_max_market_value = "<%= String(50_000_000) %>"
-btc_perps_initial_margin_ratio = "1.07"
-btc_perps_maintenance_margin_scalar = "0.333"
-btc_perps_minimum_initial_margin_ratio = "0.02"
-btc_perps_flag_reward_ratio_d18 = "0.0003"
-btc_perps_max_liquidation_limit_accumulation_multiplier = "1.5"
+btc_perps_market_skew_scale = "<%= parseEther(String(35_000)) %>"
+btc_perps_market_max_funding_velocity = "<%= parseEther('9') %>"
+btc_perps_maker_fee_ratio = "<%= parseEther('0') %>"
+btc_perps_taker_fee_ratio = "<%= parseEther('0.0005') %>"
+btc_perps_max_market_size = "<%= parseEther('1200') %>"
+btc_perps_max_market_value = "<%= parseEther(String(50_000_000)) %>"
+btc_perps_initial_margin_ratio = "<%= parseEther('1.07') %>"
+btc_perps_maintenance_margin_scalar = "<%= parseEther('0.333') %>"
+btc_perps_minimum_initial_margin_ratio = "<%= parseEther('0.02') %>"
+btc_perps_flag_reward_ratio_d18 = "<%= parseEther('0.0003') %>"
+btc_perps_max_liquidation_limit_accumulation_multiplier = "<%= parseEther('1.5') %>"
 btc_perps_max_seconds_in_liquidation_window = "30"
-btc_perps_minimum_position_margin = "50"
-btc_perps_locked_oi_ratio = "0.25"
-btc_perps_max_liquidation_pd = "0.0005"
+btc_perps_minimum_position_margin = "<%= parseEther('50') %>"
+btc_perps_locked_oi_ratio = "<%= parseEther('0.25') %>"
+btc_perps_max_liquidation_pd = "<%= parseEther('0.0005') %>"
 btc_perps_endorsed_liquidator = "0x95A61Fa7454CA5f6A3CE01724e306Cd14a22D306"
 
 [invoke.createBtcPerpsMarket]
@@ -22,7 +22,6 @@ target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "createMarket"
 args = ["<%= settings.btc_perps_market_id %>", "Bitcoin", "BTC"]
-depends = ["var.perps_btc_market_settings"]
 
 [invoke.setPerpsPriceBtc]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -33,9 +32,7 @@ args = [
     "<%= extras.btc_oracle_id %>",
     "<%= settings.big_cap_strict_staleness_tolerance %>",
 ]
-depends = ["invoke.createBtcPerpsMarket", "var.perps_btc_market_settings"]
 
-# DO NOT MODIFY THIS STEP!. Edit [invoke.setPerpsBtcSettlementStrategy] instead.
 [invoke.addPerpsBtcSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
@@ -46,7 +43,6 @@ args = [
 ]
 extra.btc_pyth_settlement_strategy.event = "SettlementStrategyAdded"
 extra.btc_pyth_settlement_strategy.arg = 2
-depends = ["invoke.createBtcPerpsMarket"]
 
 [invoke.setPerpsBtcSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -54,14 +50,8 @@ fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.btc_perps_market_id %>",
-    "<%= extras.btc_pyth_settlement_strategy %>",                                                                                                                                                                                                                                                                                                                                                                                                                          # Settlement Strategy ID
+    "<%= extras.btc_pyth_settlement_strategy %>",
     { strategyType = "0", settlementDelay = "<%= settings.big_cap_settlement_delay %>", settlementWindowDuration = "<%= settings.big_cap_settlement_window_duration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pyth_feed_id_btc %>", settlementReward = "<%= settings.settlement_reward %>", disabled = false, commitmentPriceDelay = "<%= settings.commitment_price_delay %>" },
-]
-depends = [
-    'provision.perpsFactory',
-    'var.perps_btc_market_settings',
-    'invoke.addPerpsBtcSettlementStrategy',
-    'provision.pyth_erc7412_wrapper',
 ]
 
 [invoke.setPerpsBtcFundingParameters]
@@ -70,10 +60,9 @@ fromCall.func = "owner"
 func = "setFundingParameters"
 args = [
     "<%= settings.btc_perps_market_id %>",
-    "<%= parseEther(settings.btc_perps_market_skew_scale) %>",
-    "<%= parseEther(settings.btc_perps_market_max_funding_velocity) %>",
+    "<%= settings.btc_perps_market_skew_scale %>",
+    "<%= settings.btc_perps_market_max_funding_velocity %>",
 ]
-depends = ["invoke.createBtcPerpsMarket", "var.perps_btc_market_settings"]
 
 [invoke.setPerpsBtcOrderFees]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -81,30 +70,21 @@ fromCall.func = "owner"
 func = "setOrderFees"
 args = [
     "<%= settings.btc_perps_market_id %>",
-    "<%= parseEther(settings.btc_perps_maker_fee_ratio) %>",
-    "<%= parseEther(settings.btc_perps_taker_fee_ratio) %>",
+    "<%= settings.btc_perps_maker_fee_ratio %>",
+    "<%= settings.btc_perps_taker_fee_ratio %>",
 ]
-depends = ["invoke.createBtcPerpsMarket", "var.perps_btc_market_settings"]
 
 [invoke.setPerpsBtcMaxMarketSize]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxMarketSize"
-args = [
-    "<%= settings.btc_perps_market_id %>",
-    "<%= parseEther(settings.btc_perps_max_market_size) %>",
-]
-depends = ["invoke.createBtcPerpsMarket", "var.perps_btc_market_settings"]
+args = ["<%= settings.btc_perps_market_id %>", "<%= settings.btc_perps_max_market_size %>"]
 
 [invoke.setPerpsBtcMaxMarketValue]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxMarketValue"
-args = [
-    "<%= settings.btc_perps_market_id %>",
-    "<%= parseEther(settings.btc_perps_max_market_value) %>",
-]
-depends = ["invoke.createBtcPerpsMarket", "var.perps_btc_market_settings"]
+args = ["<%= settings.btc_perps_market_id %>", "<%= settings.btc_perps_max_market_value %>"]
 
 [invoke.setPerpsBtcMaxLiquidationParameters]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -112,12 +92,11 @@ fromCall.func = "owner"
 func = "setMaxLiquidationParameters"
 args = [
     "<%= settings.btc_perps_market_id %>",
-    "<%= parseEther(settings.btc_perps_max_liquidation_limit_accumulation_multiplier) %>",
+    "<%= settings.btc_perps_max_liquidation_limit_accumulation_multiplier %>",
     "<%= settings.btc_perps_max_seconds_in_liquidation_window %>",
-    "<%= parseEther(settings.btc_perps_max_liquidation_pd) %>",
+    "<%= settings.btc_perps_max_liquidation_pd %>",
     "<%= settings.btc_perps_endorsed_liquidator %>",
 ]
-depends = ["invoke.createBtcPerpsMarket", "var.perps_btc_market_settings"]
 
 [invoke.setPerpsBtcLiquidationParameters]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -125,20 +104,15 @@ fromCall.func = "owner"
 func = "setLiquidationParameters"
 args = [
     "<%= settings.btc_perps_market_id %>",
-    "<%= parseEther(settings.btc_perps_initial_margin_ratio) %>",
-    "<%= parseEther(settings.btc_perps_minimum_initial_margin_ratio) %>",
-    "<%= parseEther(settings.btc_perps_maintenance_margin_scalar) %>",
-    "<%= parseEther(settings.btc_perps_flag_reward_ratio_d18) %>",
-    "<%= parseEther(settings.btc_perps_minimum_position_margin) %>",
+    "<%= settings.btc_perps_initial_margin_ratio %>",
+    "<%= settings.btc_perps_minimum_initial_margin_ratio %>",
+    "<%= settings.btc_perps_maintenance_margin_scalar %>",
+    "<%= settings.btc_perps_flag_reward_ratio_d18 %>",
+    "<%= settings.btc_perps_minimum_position_margin %>",
 ]
-depends = ["invoke.createBtcPerpsMarket", "var.perps_btc_market_settings"]
 
 [invoke.setPerpsBtcLockedOiRatio]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setLockedOiRatio"
-args = [
-    "<%= settings.btc_perps_market_id %>",
-    "<%= parseEther(settings.btc_perps_locked_oi_ratio) %>",
-]
-depends = ["invoke.createBtcPerpsMarket", "var.perps_btc_market_settings"]
+args = ["<%= settings.btc_perps_market_id %>", "<%= settings.btc_perps_locked_oi_ratio %>"]

--- a/tomls/omnibus-arbitrum-sepolia/perps/markets/eth.toml
+++ b/tomls/omnibus-arbitrum-sepolia/perps/markets/eth.toml
@@ -1,20 +1,20 @@
 [var.perps_eth_market_settings]
 eth_perps_market_id = "100"
-eth_perps_market_skew_scale = "<%= String(350_000) %>"
-eth_perps_market_max_funding_velocity = "9"
-eth_perps_maker_fee_ratio = "0"
-eth_perps_taker_fee_ratio = "0.0005"
-eth_perps_max_market_size = "<%= String(15_000) %>"
-eth_perps_max_market_value = "<%= String(40_000_000) %>"
-eth_perps_initial_margin_ratio = "0.744"
-eth_perps_minimum_initial_margin_ratio = "0.02"
-eth_perps_maintenance_margin_scalar = "0.333"
-eth_perps_flag_reward_ratio = "0.0003"
-eth_perps_minimum_position_margin = "50"
-eth_perps_locked_oi_ratio = "0.25"
-eth_perps_max_liquidation_limit_accumulation_multiplier = "1.5"
+eth_perps_market_skew_scale = "<%= parseEther(String(350_000)) %>"
+eth_perps_market_max_funding_velocity = "<%= parseEther('9') %>"
+eth_perps_maker_fee_ratio = "<%= parseEther('0') %>"
+eth_perps_taker_fee_ratio = "<%= parseEther('0.0005') %>"
+eth_perps_max_market_size = "<%= parseEther(String(15_000)) %>"
+eth_perps_max_market_value = "<%= parseEther(String(40_000_000)) %>"
+eth_perps_initial_margin_ratio = "<%= parseEther('0.744') %>"
+eth_perps_minimum_initial_margin_ratio = "<%= parseEther('0.02') %>"
+eth_perps_maintenance_margin_scalar = "<%= parseEther('0.333') %>"
+eth_perps_flag_reward_ratio = "<%= parseEther('0.0003') %>"
+eth_perps_minimum_position_margin = "<%= parseEther('50') %>"
+eth_perps_locked_oi_ratio = "<%= parseEther('0.25') %>"
+eth_perps_max_liquidation_limit_accumulation_multiplier = "<%= parseEther('1.5') %>"
 eth_perps_max_seconds_in_liquidation_window = "30"
-eth_perps_max_liquidation_pd = "0.0005"
+eth_perps_max_liquidation_pd = "<%= parseEther('0.0005') %>"
 eth_perps_endorsed_liquidator = "0x95A61Fa7454CA5f6A3CE01724e306Cd14a22D306"
 
 [invoke.createEthPerpsMarket]
@@ -22,11 +22,7 @@ target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "createMarket"
 args = ["<%= settings.eth_perps_market_id %>", "Ethereum", "ETH"]
-depends = [
-    "var.perps_eth_market_settings",
-    "invoke.PerpsMarketProxy_setFeatureFlagAllowAll_perpsSystem",
-    "invoke.PerpsMarketProxy_addToFeatureFlagAllowlist_createMarket_deployer",
-]
+depends = ["invoke.PerpsMarketProxy_addToFeatureFlagAllowlist_createMarket_deployer"]
 
 [invoke.setPerpsPriceEth]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -37,7 +33,6 @@ args = [
     "<%= extras.eth_oracle_id %>",
     "<%= settings.big_cap_strict_staleness_tolerance %>",
 ]
-depends = ["invoke.createEthPerpsMarket", "var.perps_eth_market_settings"]
 
 # Do not modify this step. Edit [invoke.setPerpsEthSettlementStrategy] instead.
 [invoke.addPerpsEthSettlementStrategy]
@@ -50,7 +45,6 @@ args = [
 ]
 extra.eth_pyth_settlement_strategy.event = "SettlementStrategyAdded"
 extra.eth_pyth_settlement_strategy.arg = 2
-depends = ["invoke.createEthPerpsMarket", "var.perps_eth_market_settings"]
 
 [invoke.setPerpsEthSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -58,19 +52,8 @@ fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.eth_perps_market_id %>",
-    "<%= extras.eth_pyth_settlement_strategy %>",                                                                                                                                                                                                                                                                                                                                                                                                                          # Settlement Strategy ID
+    "<%= extras.eth_pyth_settlement_strategy %>",
     { strategyType = "0", settlementDelay = "<%= settings.big_cap_settlement_delay %>", settlementWindowDuration = "<%= settings.big_cap_settlement_window_duration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pyth_feed_id_eth %>", settlementReward = "<%= settings.settlement_reward %>", disabled = false, commitmentPriceDelay = "<%= settings.commitment_price_delay %>" },
-]
-depends = [
-    'provision.perpsFactory',
-    'var.perps_eth_market_settings',
-    'invoke.addPerpsEthSettlementStrategy',
-    'provision.pyth_erc7412_wrapper',
-    'setting.big_cap_settlement_delay',
-    'setting.big_cap_settlement_window_duration',
-    'setting.pyth_feed_id_eth',
-    'setting.settlement_reward',
-    'setting.commitment_price_delay',
 ]
 
 [invoke.setPerpsEthFundingParameters]
@@ -79,10 +62,9 @@ fromCall.func = "owner"
 func = "setFundingParameters"
 args = [
     "<%= settings.eth_perps_market_id %>",
-    "<%= parseEther(settings.eth_perps_market_skew_scale) %>",
-    "<%= parseEther(settings.eth_perps_market_max_funding_velocity) %>",
+    "<%= settings.eth_perps_market_skew_scale %>",
+    "<%= settings.eth_perps_market_max_funding_velocity %>",
 ]
-depends = ["invoke.createEthPerpsMarket", "var.perps_eth_market_settings"]
 
 [invoke.setPerpsEthOrderFees]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -90,30 +72,21 @@ fromCall.func = "owner"
 func = "setOrderFees"
 args = [
     "<%= settings.eth_perps_market_id %>",
-    "<%= parseEther(settings.eth_perps_maker_fee_ratio) %>",
-    "<%= parseEther(settings.eth_perps_taker_fee_ratio) %>",
+    "<%= settings.eth_perps_maker_fee_ratio %>",
+    "<%= settings.eth_perps_taker_fee_ratio %>",
 ]
-depends = ["invoke.createEthPerpsMarket", "var.perps_eth_market_settings"]
 
 [invoke.setPerpsEthMaxMarketSize]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxMarketSize"
-args = [
-    "<%= settings.eth_perps_market_id %>",
-    "<%= parseEther(settings.eth_perps_max_market_size) %>",
-]
-depends = ["invoke.createEthPerpsMarket", "var.perps_eth_market_settings"]
+args = ["<%= settings.eth_perps_market_id %>", "<%= settings.eth_perps_max_market_size %>"]
 
 [invoke.setPerpsEthMaxMarketValue]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxMarketValue"
-args = [
-    "<%= settings.eth_perps_market_id %>",
-    "<%= parseEther(settings.eth_perps_max_market_value) %>",
-]
-depends = ["invoke.createEthPerpsMarket", "var.perps_eth_market_settings"]
+args = ["<%= settings.eth_perps_market_id %>", "<%= settings.eth_perps_max_market_value %>"]
 
 [invoke.setPerpsEthMaxLiquidationParameters]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -121,12 +94,11 @@ fromCall.func = "owner"
 func = "setMaxLiquidationParameters"
 args = [
     "<%= settings.eth_perps_market_id %>",
-    "<%= parseEther(settings.eth_perps_max_liquidation_limit_accumulation_multiplier) %>",
+    "<%= settings.eth_perps_max_liquidation_limit_accumulation_multiplier %>",
     "<%= settings.eth_perps_max_seconds_in_liquidation_window %>",
-    "<%= parseEther(settings.eth_perps_max_liquidation_pd) %>",
+    "<%= settings.eth_perps_max_liquidation_pd %>",
     "<%= settings.eth_perps_endorsed_liquidator %>",
 ]
-depends = ["invoke.createEthPerpsMarket", "var.perps_eth_market_settings"]
 
 [invoke.setPerpsEthLiquidationParameters]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -134,20 +106,15 @@ fromCall.func = "owner"
 func = "setLiquidationParameters"
 args = [
     "<%= settings.eth_perps_market_id %>",
-    "<%= parseEther(settings.eth_perps_initial_margin_ratio) %>",
-    "<%= parseEther(settings.eth_perps_minimum_initial_margin_ratio) %>",
-    "<%= parseEther(settings.eth_perps_maintenance_margin_scalar) %>",
-    "<%= parseEther(settings.eth_perps_flag_reward_ratio) %>",
-    "<%= parseEther(settings.eth_perps_minimum_position_margin) %>",
+    "<%= settings.eth_perps_initial_margin_ratio %>",
+    "<%= settings.eth_perps_minimum_initial_margin_ratio %>",
+    "<%= settings.eth_perps_maintenance_margin_scalar %>",
+    "<%= settings.eth_perps_flag_reward_ratio %>",
+    "<%= settings.eth_perps_minimum_position_margin %>",
 ]
-depends = ["invoke.createEthPerpsMarket", "var.perps_eth_market_settings"]
 
 [invoke.setPerpsEthLockedOiRatio]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setLockedOiRatio"
-args = [
-    "<%= settings.eth_perps_market_id %>",
-    "<%= parseEther(settings.eth_perps_locked_oi_ratio) %>",
-]
-depends = ["invoke.createEthPerpsMarket", "var.perps_eth_market_settings"]
+args = ["<%= settings.eth_perps_market_id %>", "<%= settings.eth_perps_locked_oi_ratio %>"]

--- a/tomls/omnibus-arbitrum-sepolia/perps/markets/sol.toml
+++ b/tomls/omnibus-arbitrum-sepolia/perps/markets/sol.toml
@@ -1,20 +1,20 @@
 [var.perps_sol_market_settings]
 sol_perps_market_id = "300"
-sol_perps_market_skew_scale = "<%= String(1_406_250) %>"
-sol_perps_market_max_funding_velocity = "9"
-sol_perps_maker_fee_ratio = "0"
-sol_perps_taker_fee_ratio = "0.0008"
-sol_perps_max_market_size = "<%= String(270_000) %>"
-sol_perps_max_market_value = "<%= String(40_000_000) %>"
-sol_perps_initial_margin_ratio = "5.503"
-sol_perps_maintenance_margin_scalar = "0.333"
-sol_perps_minimum_initial_margin_ratio = "0.02"
-sol_perps_flag_reward_ratio_d18 = "0.0003"
-sol_perps_max_liquidation_limit_accumulation_multiplier = "1.5"
+sol_perps_market_skew_scale = "<%= parseEther(String(1_406_250)) %>"
+sol_perps_market_max_funding_velocity = "<%= parseEther('9') %>"
+sol_perps_maker_fee_ratio = "<%= parseEther('0') %>"
+sol_perps_taker_fee_ratio = "<%= parseEther('0.0008') %>"
+sol_perps_max_market_size = "<%= parseEther(String(270_000)) %>"
+sol_perps_max_market_value = "<%= parseEther(String(40_000_000)) %>"
+sol_perps_initial_margin_ratio = "<%= parseEther('5.503') %>"
+sol_perps_maintenance_margin_scalar = "<%= parseEther('0.333') %>"
+sol_perps_minimum_initial_margin_ratio = "<%= parseEther('0.02') %>"
+sol_perps_flag_reward_ratio_d18 = "<%= parseEther('0.0003') %>"
+sol_perps_max_liquidation_limit_accumulation_multiplier = "<%= parseEther('1.5') %>"
 sol_perps_max_seconds_in_liquidation_window = "30"
-sol_perps_minimum_position_margin = "50"
-sol_perps_locked_oi_ratio = "0.50"
-sol_perps_max_liquidation_pd = "0.0005"
+sol_perps_minimum_position_margin = "<%= parseEther('50') %>"
+sol_perps_locked_oi_ratio = "<%= parseEther('0.50') %>"
+sol_perps_max_liquidation_pd = "<%= parseEther('0.0005') %>"
 sol_perps_endorsed_liquidator = "0x95A61Fa7454CA5f6A3CE01724e306Cd14a22D306"
 
 [invoke.createSolPerpsMarket]
@@ -33,7 +33,6 @@ args = [
     "<%= extras.sol_oracle_id %>",
     "<%= settings.big_cap_strict_staleness_tolerance %>",
 ]
-depends = ["invoke.createSolPerpsMarket", "var.perps_sol_market_settings"]
 
 # DO NOT MODIFY THIS STEP!. Edit [invoke.setPerpsSolSettlementStrategy] instead.
 [invoke.addPerpsSolSettlementStrategy]
@@ -46,7 +45,6 @@ args = [
 ]
 extra.sol_pyth_settlement_strategy.event = "SettlementStrategyAdded"
 extra.sol_pyth_settlement_strategy.arg = 2
-depends = ["invoke.createSolPerpsMarket"]
 
 [invoke.setPerpsSolSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -54,14 +52,8 @@ fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.sol_perps_market_id %>",
-    "<%= extras.sol_pyth_settlement_strategy %>",                                                                                                                                                                                                                                                                                                                                                                                                                          # Settlement Strategy ID
+    "<%= extras.sol_pyth_settlement_strategy %>",
     { strategyType = "0", settlementDelay = "<%= settings.big_cap_settlement_delay %>", settlementWindowDuration = "<%= settings.big_cap_settlement_window_duration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pyth_feed_id_sol %>", settlementReward = "<%= settings.settlement_reward %>", disabled = false, commitmentPriceDelay = "<%= settings.commitment_price_delay %>" },
-]
-depends = [
-    'provision.perpsFactory',
-    'var.perps_sol_market_settings',
-    'invoke.addPerpsSolSettlementStrategy',
-    'provision.pyth_erc7412_wrapper',
 ]
 
 [invoke.setPerpsSolFundingParameters]
@@ -70,10 +62,9 @@ fromCall.func = "owner"
 func = "setFundingParameters"
 args = [
     "<%= settings.sol_perps_market_id %>",
-    "<%= parseEther(settings.sol_perps_market_skew_scale) %>",
-    "<%= parseEther(settings.sol_perps_market_max_funding_velocity) %>",
+    "<%= settings.sol_perps_market_skew_scale %>",
+    "<%= settings.sol_perps_market_max_funding_velocity %>",
 ]
-depends = ["invoke.createSolPerpsMarket", "var.perps_sol_market_settings"]
 
 [invoke.setPerpsSolOrderFees]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -81,30 +72,21 @@ fromCall.func = "owner"
 func = "setOrderFees"
 args = [
     "<%= settings.sol_perps_market_id %>",
-    "<%= parseEther(settings.sol_perps_maker_fee_ratio) %>",
-    "<%= parseEther(settings.sol_perps_taker_fee_ratio) %>",
+    "<%= settings.sol_perps_maker_fee_ratio %>",
+    "<%= settings.sol_perps_taker_fee_ratio %>",
 ]
-depends = ["invoke.createSolPerpsMarket", "var.perps_sol_market_settings"]
 
 [invoke.setPerpsSolMaxMarketSize]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxMarketSize"
-args = [
-    "<%= settings.sol_perps_market_id %>",
-    "<%= parseEther(settings.sol_perps_max_market_size) %>",
-]
-depends = ["invoke.createSolPerpsMarket", "var.perps_sol_market_settings"]
+args = ["<%= settings.sol_perps_market_id %>", "<%= settings.sol_perps_max_market_size %>"]
 
 [invoke.setPerpsSolMaxMarketValue]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxMarketValue"
-args = [
-    "<%= settings.sol_perps_market_id %>",
-    "<%= parseEther(settings.sol_perps_max_market_value) %>",
-]
-depends = ["invoke.createSolPerpsMarket", "var.perps_sol_market_settings"]
+args = ["<%= settings.sol_perps_market_id %>", "<%= settings.sol_perps_max_market_value %>"]
 
 [invoke.setPerpsSolMaxLiquidationParameters]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -112,12 +94,11 @@ fromCall.func = "owner"
 func = "setMaxLiquidationParameters"
 args = [
     "<%= settings.sol_perps_market_id %>",
-    "<%= parseEther(settings.sol_perps_max_liquidation_limit_accumulation_multiplier) %>",
+    "<%= settings.sol_perps_max_liquidation_limit_accumulation_multiplier %>",
     "<%= settings.sol_perps_max_seconds_in_liquidation_window %>",
-    "<%= parseEther(settings.sol_perps_max_liquidation_pd) %>",
+    "<%= settings.sol_perps_max_liquidation_pd %>",
     "<%= settings.sol_perps_endorsed_liquidator %>",
 ]
-depends = ["invoke.createSolPerpsMarket", "var.perps_sol_market_settings"]
 
 [invoke.setPerpsSolLiquidationParameters]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -125,20 +106,15 @@ fromCall.func = "owner"
 func = "setLiquidationParameters"
 args = [
     "<%= settings.sol_perps_market_id %>",
-    "<%= parseEther(settings.sol_perps_initial_margin_ratio) %>",
-    "<%= parseEther(settings.sol_perps_minimum_initial_margin_ratio) %>",
-    "<%= parseEther(settings.sol_perps_maintenance_margin_scalar) %>",
-    "<%= parseEther(settings.sol_perps_flag_reward_ratio_d18) %>",
-    "<%= parseEther(settings.sol_perps_minimum_position_margin) %>",
+    "<%= settings.sol_perps_initial_margin_ratio %>",
+    "<%= settings.sol_perps_minimum_initial_margin_ratio %>",
+    "<%= settings.sol_perps_maintenance_margin_scalar %>",
+    "<%= settings.sol_perps_flag_reward_ratio_d18 %>",
+    "<%= settings.sol_perps_minimum_position_margin %>",
 ]
-depends = ["invoke.createSolPerpsMarket", "var.perps_sol_market_settings"]
 
 [invoke.setPerpsSolLockedOiRatio]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setLockedOiRatio"
-args = [
-    "<%= settings.sol_perps_market_id %>",
-    "<%= parseEther(settings.sol_perps_locked_oi_ratio) %>",
-]
-depends = ["invoke.createSolPerpsMarket", "var.perps_sol_market_settings"]
+args = ["<%= settings.sol_perps_market_id %>", "<%= settings.sol_perps_locked_oi_ratio %>"]

--- a/tomls/omnibus-arbitrum-sepolia/perps/markets/wif.toml
+++ b/tomls/omnibus-arbitrum-sepolia/perps/markets/wif.toml
@@ -1,20 +1,20 @@
 [var.perps_wif_market_settings]
 wif_perps_market_id = "400"
-wif_perps_market_skew_scale = "<%= String(15_000_000) %>"
-wif_perps_market_max_funding_velocity = "36"
-wif_perps_maker_fee_ratio = "0"
-wif_perps_taker_fee_ratio = "0.0010"
-wif_perps_max_market_size = "<%= String(2_500_000) %>"
-wif_perps_max_market_value = "<%= String(3_000_000) %>"
-wif_perps_initial_margin_ratio = "1"
-wif_perps_maintenance_margin_scalar = "0.5"
-wif_perps_minimum_initial_margin_ratio = "0.04"
-wif_perps_flag_reward_ratio_d18 = "0.0003"
-wif_perps_max_liquidation_limit_accumulation_multiplier = "1.5"
+wif_perps_market_skew_scale = "<%= parseEther(String(15_000_000)) %>"
+wif_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
+wif_perps_maker_fee_ratio = "<%= parseEther('0') %>"
+wif_perps_taker_fee_ratio = "<%= parseEther('0.0010') %>"
+wif_perps_max_market_size = "<%= parseEther(String(2_500_000)) %>"
+wif_perps_max_market_value = "<%= parseEther(String(3_000_000)) %>"
+wif_perps_initial_margin_ratio = "<%= parseEther('1') %>"
+wif_perps_maintenance_margin_scalar = "<%= parseEther('0.5') %>"
+wif_perps_minimum_initial_margin_ratio = "<%= parseEther('0.04') %>"
+wif_perps_flag_reward_ratio_d18 = "<%= parseEther('0.0003') %>"
+wif_perps_max_liquidation_limit_accumulation_multiplier = "<%= parseEther('1.5') %>"
 wif_perps_max_seconds_in_liquidation_window = "30"
-wif_perps_minimum_position_margin = "50"
-wif_perps_locked_oi_ratio = "0.50"
-wif_perps_max_liquidation_pd = "0.0005"
+wif_perps_minimum_position_margin = "<%= parseEther('50') %>"
+wif_perps_locked_oi_ratio = "<%= parseEther('0.50') %>"
+wif_perps_max_liquidation_pd = "<%= parseEther('0.0005') %>"
 wif_perps_endorsed_liquidator = "0x95A61Fa7454CA5f6A3CE01724e306Cd14a22D306"
 
 [invoke.createWifPerpsMarket]
@@ -22,7 +22,6 @@ target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "createMarket"
 args = ["<%= settings.wif_perps_market_id %>", "dogwifhat", "Wif"]
-depends = ["var.perps_wif_market_settings"]
 
 [invoke.setPerpsPriceWif]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -33,35 +32,26 @@ args = [
     "<%= extras.wif_oracle_id %>",
     "<%= settings.big_cap_strict_staleness_tolerance %>",
 ]
-depends = ["invoke.createWifPerpsMarket", "var.perps_wif_market_settings"]
 
-# DO NOT MODIFY THIS STEP!. Edit [invoke.setPerpsWifSettlementStrategy] instead.
 [invoke.addPerpsWifSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "addSettlementStrategy"
 args = [
     "<%= settings.wif_perps_market_id %>",
+
     { strategyType = "0", settlementDelay = "0", settlementWindowDuration = "1", priceVerificationContract = "0x0000000000000000000000000000000000000000", feedId = "0x0000000000000000000000000000000000000000000000000000000000000000", settlementReward = "0", disabled = false, commitmentPriceDelay = "0" },
 ]
 extra.wif_pyth_settlement_strategy.event = "SettlementStrategyAdded"
 extra.wif_pyth_settlement_strategy.arg = 2
-depends = ["invoke.createWifPerpsMarket"]
-
 [invoke.setPerpsWifSettlementStrategy]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setSettlementStrategy"
 args = [
     "<%= settings.wif_perps_market_id %>",
-    "<%= extras.wif_pyth_settlement_strategy %>",                                                                                                                                                                                                                                                                                                                                                                                                                          # Settlement Strategy ID
+    "<%= extras.wif_pyth_settlement_strategy %>",
     { strategyType = "0", settlementDelay = "<%= settings.big_cap_settlement_delay %>", settlementWindowDuration = "<%= settings.big_cap_settlement_window_duration %>", priceVerificationContract = "<%= imports.pyth_erc7412_wrapper.contracts.PythERC7412Wrapper.address %>", feedId = "<%= settings.pyth_feed_id_wif %>", settlementReward = "<%= settings.settlement_reward %>", disabled = false, commitmentPriceDelay = "<%= settings.commitment_price_delay %>" },
-]
-depends = [
-    'provision.perpsFactory',
-    'var.perps_wif_market_settings',
-    'invoke.addPerpsWifSettlementStrategy',
-    'provision.pyth_erc7412_wrapper',
 ]
 
 [invoke.setPerpsWifFundingParameters]
@@ -70,10 +60,9 @@ fromCall.func = "owner"
 func = "setFundingParameters"
 args = [
     "<%= settings.wif_perps_market_id %>",
-    "<%= parseEther(settings.wif_perps_market_skew_scale) %>",
-    "<%= parseEther(settings.wif_perps_market_max_funding_velocity) %>",
+    "<%= settings.wif_perps_market_skew_scale %>",
+    "<%= settings.wif_perps_market_max_funding_velocity %>",
 ]
-depends = ["invoke.createWifPerpsMarket", "var.perps_wif_market_settings"]
 
 [invoke.setPerpsWifOrderFees]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -81,30 +70,21 @@ fromCall.func = "owner"
 func = "setOrderFees"
 args = [
     "<%= settings.wif_perps_market_id %>",
-    "<%= parseEther(settings.wif_perps_maker_fee_ratio) %>",
-    "<%= parseEther(settings.wif_perps_taker_fee_ratio) %>",
+    "<%= settings.wif_perps_maker_fee_ratio %>",
+    "<%= settings.wif_perps_taker_fee_ratio %>",
 ]
-depends = ["invoke.createWifPerpsMarket", "var.perps_wif_market_settings"]
 
 [invoke.setPerpsWifMaxMarketSize]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxMarketSize"
-args = [
-    "<%= settings.wif_perps_market_id %>",
-    "<%= parseEther(settings.wif_perps_max_market_size) %>",
-]
-depends = ["invoke.createWifPerpsMarket", "var.perps_wif_market_settings"]
+args = ["<%= settings.wif_perps_market_id %>", "<%= settings.wif_perps_max_market_size %>"]
 
 [invoke.setPerpsWifMaxMarketValue]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setMaxMarketValue"
-args = [
-    "<%= settings.wif_perps_market_id %>",
-    "<%= parseEther(settings.wif_perps_max_market_value) %>",
-]
-depends = ["invoke.createWifPerpsMarket", "var.perps_wif_market_settings"]
+args = ["<%= settings.wif_perps_market_id %>", "<%= settings.wif_perps_max_market_value %>"]
 
 [invoke.setPerpsWifMaxLiquidationParameters]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -112,12 +92,11 @@ fromCall.func = "owner"
 func = "setMaxLiquidationParameters"
 args = [
     "<%= settings.wif_perps_market_id %>",
-    "<%= parseEther(settings.wif_perps_max_liquidation_limit_accumulation_multiplier) %>",
+    "<%= settings.wif_perps_max_liquidation_limit_accumulation_multiplier %>",
     "<%= settings.wif_perps_max_seconds_in_liquidation_window %>",
-    "<%= parseEther(settings.wif_perps_max_liquidation_pd) %>",
+    "<%= settings.wif_perps_max_liquidation_pd %>",
     "<%= settings.wif_perps_endorsed_liquidator %>",
 ]
-depends = ["invoke.createWifPerpsMarket", "var.perps_wif_market_settings"]
 
 [invoke.setPerpsWifLiquidationParameters]
 target = ["perpsFactory.PerpsMarketProxy"]
@@ -125,20 +104,15 @@ fromCall.func = "owner"
 func = "setLiquidationParameters"
 args = [
     "<%= settings.wif_perps_market_id %>",
-    "<%= parseEther(settings.wif_perps_initial_margin_ratio) %>",
-    "<%= parseEther(settings.wif_perps_minimum_initial_margin_ratio) %>",
-    "<%= parseEther(settings.wif_perps_maintenance_margin_scalar) %>",
-    "<%= parseEther(settings.wif_perps_flag_reward_ratio_d18) %>",
-    "<%= parseEther(settings.wif_perps_minimum_position_margin) %>",
+    "<%= settings.wif_perps_initial_margin_ratio %>",
+    "<%= settings.wif_perps_minimum_initial_margin_ratio %>",
+    "<%= settings.wif_perps_maintenance_margin_scalar %>",
+    "<%= settings.wif_perps_flag_reward_ratio_d18 %>",
+    "<%= settings.wif_perps_minimum_position_margin %>",
 ]
-depends = ["invoke.createWifPerpsMarket", "var.perps_wif_market_settings"]
 
 [invoke.setPerpsWifLockedOiRatio]
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "setLockedOiRatio"
-args = [
-    "<%= settings.wif_perps_market_id %>",
-    "<%= parseEther(settings.wif_perps_locked_oi_ratio) %>",
-]
-depends = ["invoke.createWifPerpsMarket", "var.perps_wif_market_settings"]
+args = ["<%= settings.wif_perps_market_id %>", "<%= settings.wif_perps_locked_oi_ratio %>"]


### PR DESCRIPTION
no changes in the deployment as all values are exactly same
- remove `parseEthers` from invoke steps and only use them in settings
- cleanup `depends`