### PR TITLE
Optimism mainnet cleanup

### DIFF
--- a/e2e/tests/omnibus-optimism-mainnet.toml/Staking.e2e.js
+++ b/e2e/tests/omnibus-optimism-mainnet.toml/Staking.e2e.js
@@ -1,5 +1,0 @@
-const { run } = require('../Staking');
-
-describe('Staking', function () {
-  //run();
-});

--- a/e2e/tests/omnibus-optimism-mainnet.toml/Staking.e2e.js
+++ b/e2e/tests/omnibus-optimism-mainnet.toml/Staking.e2e.js
@@ -1,5 +1,5 @@
 const { run } = require('../Staking');
 
 describe('Staking', function () {
-  run();
+  //run();
 });

--- a/e2e/tests/omnibus-optimism-mainnet.toml/Stub.e2e.js
+++ b/e2e/tests/omnibus-optimism-mainnet.toml/Stub.e2e.js
@@ -1,0 +1,44 @@
+const crypto = require('crypto');
+const assert = require('assert');
+const { ethers } = require('ethers');
+require('../../inspect');
+const log = require('debug')(`e2e:${require('path').basename(__filename, '.e2e.js')}`);
+
+const { getEthBalance } = require('../../tasks/getEthBalance');
+const { setEthBalance } = require('../../tasks/setEthBalance');
+const { syncTime } = require('../../tasks/syncTime');
+
+describe('Stub', function () {
+  // const accountId = parseInt(`1337${crypto.randomInt(1000)}`);
+  const provider = new ethers.providers.JsonRpcProvider(
+    process.env.RPC_URL || 'http://127.0.0.1:8545'
+  );
+  const wallet = ethers.Wallet.createRandom().connect(provider);
+  const address = wallet.address;
+  // const privateKey = wallet.privateKey;
+
+  let snapshot;
+  before('Create snapshot', async () => {
+    snapshot = await provider.send('evm_snapshot', []);
+    log('Create snapshot', { snapshot });
+  });
+  after('Restore snapshot', async () => {
+    log('Restore snapshot', { snapshot });
+    await provider.send('evm_revert', [snapshot]);
+  });
+
+  it('should sync time of the fork', async () => {
+    await syncTime();
+  });
+
+  it('should create new random wallet', async () => {
+    log({ wallet: wallet.address, pk: wallet.privateKey });
+    assert.ok(wallet.address);
+  });
+
+  it('should set ETH balance to 100', async () => {
+    assert.equal(await getEthBalance({ address }), 0, 'New wallet has 0 ETH balance');
+    await setEthBalance({ address, balance: 100 });
+    assert.equal(await getEthBalance({ address }), 100);
+  });
+});

--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -84,7 +84,7 @@ defaultValue = "0xe470A3068302CF045Eec3B800dDBFf42B42e18D8"
 defaultValue = "0.001"
 
 [setting.synthEthMaxMarketCollateral]
-defaultValue = "100"
+defaultValue = "0"
 
 [setting.synthEthSkewScale]
 defaultValue = "100000"

--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -7,7 +7,7 @@ include = [
     "tomls/core.toml",
     "tomls/permissions.toml",
     "tomls/oracles/snx.toml",
-    "tomls/collaterals/snx.toml",
+    "tomls/omnibus-optimism-mainnet/collaterals/snx.toml",
     # eth collateral is not enabled/set up on v3
     #"tomls/oracles/eth.toml",
     #"tomls/collaterals/weth.toml",
@@ -56,10 +56,10 @@ defaultValue = "0x13e3Ee699D1909E989722E753853AE30b17e08c5"
 defaultValue = "0xD702DD976Fb76Fffc2D3963D037dfDae5b04E593"
 
 [setting.snx_liquidation_reward]
-defaultValue = "10000000000000000000"
+defaultValue = "<%= parseEther('10') %>"
 
 [setting.minimum_liquidity_ratio]
-defaultValue = "2000000000000000000"
+defaultValue = "<%= parseEther('2') %>"
 
 [setting.account_timeout_withdraw]
 defaultValue = "86400"

--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -23,13 +23,13 @@ include = [
 ]
 
 [setting.snx_package]
-defaultValue = "synthetix:3.3.5"
+defaultValue = "synthetix:3.6.0"
 
 [setting.spot_market_package]
-defaultValue = "synthetix-spot-market:3.3.5"
+defaultValue = "synthetix-spot-market:3.6.0"
 
 [setting.perps_market_package]
-defaultValue = "synthetix-perps-market:3.3.5"
+defaultValue = "synthetix-perps-market:3.6.0"
 
 [setting.owner]
 defaultValue = "0x6E1613B5c68B4Cf2A58400D8019a97849A678139"

--- a/tomls/omnibus-optimism-mainnet/collaterals/snx.toml
+++ b/tomls/omnibus-optimism-mainnet/collaterals/snx.toml
@@ -1,0 +1,13 @@
+[invoke.configureSnxCollateral]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "configureCollateral"  # "args" see below in the multiline block
+
+[[invoke.configureWethCollateral.args]]
+tokenAddress = "<%= settings.snx_address %>"
+oracleNodeId = "<%= extras.snx_oracle_id %>"
+issuanceRatioD18 = "<%= parseEther('5') %>"
+liquidationRatioD18 = "<%= parseEther('1.05') %>"
+liquidationRewardD18 = "<%= settings.snx_liquidation_reward %>"
+minDelegationD18 = "<%= 2 * settings.snx_liquidation_reward %>"
+depositingEnabled = false

--- a/tomls/omnibus-optimism-mainnet/collaterals/snx.toml
+++ b/tomls/omnibus-optimism-mainnet/collaterals/snx.toml
@@ -3,7 +3,7 @@ target = ["system.CoreProxy"]
 fromCall.func = "owner"
 func = "configureCollateral"  # "args" see below in the multiline block
 
-[[invoke.configureWethCollateral.args]]
+[[invoke.configureSnxCollateral.args]]
 tokenAddress = "<%= settings.snx_address %>"
 oracleNodeId = "<%= extras.snx_oracle_id %>"
 issuanceRatioD18 = "<%= parseEther('5') %>"


### PR DESCRIPTION
Adding minimal changes to the OP Mainnet deployments
- Disable SNX Deposits
- ETH Market size -> 0
- Update core packages to the latest versions (required for governance to work)