### PR TITLE
Fix arbitrum sepolia deployment

### DIFF
--- a/omnibus-arbitrum-sepolia.toml
+++ b/omnibus-arbitrum-sepolia.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "29"
+version = "30"
 description = "Arbitrum deployment"
 preset = "main"
 include = [


### PR DESCRIPTION
Version 29 was not properly published so we need to do a republish with fixed cannon version.