### PR TITLE
bump tolerances

### DIFF
--- a/omnibus-arbitrum-sepolia.toml
+++ b/omnibus-arbitrum-sepolia.toml
@@ -154,7 +154,7 @@ defaultValue = "arbitrum-gas-price-oracle:3.3.16"
 defaultValue = "synthetix-spot-market:3.7.1"
 
 [setting.perps_market_package]
-defaultValue = "synthetix-perps-market:3.7.1"
+defaultValue = "synthetix-perps-market:3.6.5"
 
 [setting.buyback_snx_package]
 defaultValue = "buyback-snx:3.3.15"

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -197,7 +197,7 @@ defaultValue = "op-gas-price-oracle:3.4.0"
 defaultValue = "synthetix-spot-market:3.3.15"
 
 [setting.perps_market_package]
-defaultValue = "synthetix-perps-market:3.6.4"
+defaultValue = "synthetix-perps-market:3.6.5"
 
 [setting.buyback_snx_package]
 defaultValue = "buyback-snx:3.3.14" # Do not update! This package isn't upgradeable. A version change will deploy a new contract.


### PR DESCRIPTION
this ensures that there is a one week tolerance for base sepolia nad arbitrum

NOTE: one of the perps packages appears to be downgraded. This is because it undoes the batched errors ERC7412 changes. for now this is fine, it was only on testnet and we will bring it back to testnet next week. This is mostly to accelerate the process of testing, verifying, and pushing the one month tolerance of prices.