### PR TITLE
release 3.10 testnets

### DIFF
--- a/omnibus-arbitrum-sepolia.toml
+++ b/omnibus-arbitrum-sepolia.toml
@@ -261,13 +261,13 @@ defaultValue = "main"
 defaultValue = "snax"
 
 [setting.snx_package]
-defaultValue = "synthetix:3.8.1"
+defaultValue = "synthetix:3.10.0"
 
 [setting.oracle_manager_package]
-defaultValue = "oracle-manager:3.8.1"
+defaultValue = "oracle-manager:3.10.0"
 
 [setting.perps_keeper_cost_package]
-defaultValue = "arbitrum-gas-price-oracle:3.3.16"
+defaultValue = "arbitrum-gas-price-oracle:3.10.0"
 
 [setting.spot_market_package]
 defaultValue = "synthetix-spot-market:3.8.1"
@@ -288,7 +288,7 @@ defaultValue = "https://api.synthetix.io/pyth-mainnet/api/get_vaa_ccip?data={dat
 description = "Pyth settlement strategy config"
 
 [provision.pyth_erc7412_wrapper]
-source = "pyth-erc7412-wrapper:3.3.15"
+source = "pyth-erc7412-wrapper:3.10.0"
 targetPreset = "<%= settings.target_preset %>"
 options.salt = "<%= settings.salt %>"
 options.pythAddress = "<%= settings.pyth_price_verification_address %>"

--- a/omnibus-arbitrum-sepolia.toml
+++ b/omnibus-arbitrum-sepolia.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "44"
+version = "45"
 description = "Arbitrum deployment"
 preset = "main"
 include = [

--- a/omnibus-arbitrum-sepolia.toml
+++ b/omnibus-arbitrum-sepolia.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "45"
+version = "44"
 description = "Arbitrum deployment"
 preset = "main"
 include = [

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -252,10 +252,10 @@ include = [
 ]
 
 [setting.snx_package]
-defaultValue = "synthetix:3.8.1"
+defaultValue = "synthetix:3.10.0"
 
 [setting.oracle_manager_package]
-defaultValue = "oracle-manager:3.8.1"
+defaultValue = "oracle-manager:3.10.0"
 
 [setting.perps_keeper_cost_package]
 defaultValue = "op-gas-price-oracle:3.4.0"
@@ -280,7 +280,7 @@ defaultValue = "andromeda" # Preset assigned to provisioned packages
 defaultValue = "0xA2aa501b19aff244D90cc15a4Cf739D2725B5729"
 
 [provision.pyth_erc7412_wrapper]
-source = "pyth-erc7412-wrapper:3.3.15"
+source = "pyth-erc7412-wrapper:3.10.0"
 targetPreset = "<%= settings.target_preset %>"
 options.salt = "<%= settings.salt %>"
 options.pythAddress = "<%= settings.pyth_price_verification_address %>"

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "62"
+version = "63"
 description = "Andromeda dev deployment"
 preset = "andromeda"
 include = [

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "63"
+version = "62"
 description = "Andromeda dev deployment"
 preset = "andromeda"
 include = [

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -258,7 +258,7 @@ defaultValue = "synthetix:3.10.0"
 defaultValue = "oracle-manager:3.10.0"
 
 [setting.perps_keeper_cost_package]
-defaultValue = "op-gas-price-oracle:3.4.0"
+defaultValue = "op-gas-price-oracle:3.10.0"
 
 [setting.spot_market_package]
 defaultValue = "synthetix-spot-market:3.8.1"

--- a/tomls/omnibus-arbitrum-sepolia/core.toml
+++ b/tomls/omnibus-arbitrum-sepolia/core.toml
@@ -23,4 +23,5 @@ target = "<%= settings.snx_package %>@<%= settings.target_preset %>"
 options.owner = "<%= settings.owner %>"
 options.salt = "<%= settings.salt %>"
 options.bundleSalt = "<%= settings.bundleSalt %>"
-options.oracle_manager_package = "<%= settings.oracle_manager_package %>"
+
+depends = ["clone.oracle_manager"]

--- a/tomls/omnibus-base-sepolia-andromeda/core.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/core.toml
@@ -23,7 +23,8 @@ target = "<%= settings.snx_package %>@<%= settings.target_preset %>"
 options.owner = "<%= settings.owner %>"
 options.salt = "<%= settings.salt %>"
 options.bundleSalt = "<%= settings.bundleSalt %>"
-options.oracle_manager_package = "<%= settings.oracle_manager_package %>"
+
+depends = ["clone.oracle_manager"]
 
 [invoke.CoreProxy_initOrUpgradeToken_USDToken]
 target = ["system.CoreProxy"]


### PR DESCRIPTION
btw already released this on testnets.

bump the versions for release

for the changes in the `core.toml` files, there seems to be a case where the `oracle-manager` package can be deployed after the `synthetix` system package, which can lead to unexpected failure behavior. this is fixed by adding a `depends`.

also didnt bump version because trying to figure out with @noisekit what to do with it now

want to get the mainnets merged tomorrow.