### PR TITLE
Typo Fix in `omnibus-base-mainnet.toml`

### DIFF
--- a/omnibus-base-mainnet.toml
+++ b/omnibus-base-mainnet.toml
@@ -67,7 +67,7 @@ defaultValue = "0x673aa85efd75080031d44fca061575d1da427a28"
 
 [setting.ccip_token_pool]
 # https://docs.chain.link/ccip/supported-networks#base-mainnet
-# TODO: Update when snxUSD pool availabe Base Mainnet
+# TODO: Update when snxUSD pool available Base Mainnet
 defaultValue = "0x0000000000000000000000000000000000000000"
 
 # ETH Synth Configuration


### PR DESCRIPTION
## Typo Fix in `omnibus-base-mainnet.toml`

This pull request fixes a typo in the `omnibus-base-mainnet.toml` file. The word "availabe" has been corrected to "available."

### Changes:
- Fixed the typo from "availabe" to "available" in the configuration file.

### Checklist:
- [x] Typo corrected.
- [x] Changes have been reviewed and tested.
