### PR TITLE
sccp-392

### DIFF
--- a/omnibus-base-mainnet-andromeda.toml
+++ b/omnibus-base-mainnet-andromeda.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "81"
+version = "82"
 description = "Andromeda deployment"
 preset = "andromeda"
 deployers = [

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "80"
+version = "81"
 description = "Andromeda dev deployment"
 preset = "andromeda"
 deployers = ["0x48914229deDd5A9922f44441ffCCfC2Cb7856Ee9"]

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/aave.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/aave.toml
@@ -1,6 +1,6 @@
 [var.perps_aave_market_settings]
 aave_perps_market_id = "3300"
-aave_perps_market_skew_scale = "<%= parseEther(String(103_900)) %>"
+aave_perps_market_skew_scale = "<%= parseEther(String(163_000)) %>"
 aave_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 aave_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 aave_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/ada.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/ada.toml
@@ -1,6 +1,6 @@
 [var.perps_ada_market_settings]
 ada_perps_market_id = "3400"
-ada_perps_market_skew_scale = "<%= parseEther(String(82_468_000)) %>"
+ada_perps_market_skew_scale = "<%= parseEther(String(221_196_000)) %>"
 ada_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 ada_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 ada_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/algo.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/algo.toml
@@ -1,6 +1,6 @@
 [var.perps_algo_market_settings]
 algo_perps_market_id = "3500"
-algo_perps_market_skew_scale = "<%= parseEther(String(54_100_700)) %>"
+algo_perps_market_skew_scale = "<%= parseEther(String(86_271_000)) %>"
 algo_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 algo_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 algo_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/axs.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/axs.toml
@@ -1,6 +1,6 @@
 [var.perps_axs_market_settings]
 axs_perps_market_id = "3800"
-axs_perps_market_skew_scale = "<%= parseEther(String(2_218_700)) %>"
+axs_perps_market_skew_scale = "<%= parseEther(String(3_341_000)) %>"
 axs_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 axs_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 axs_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/bch.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/bch.toml
@@ -1,6 +1,6 @@
 [var.perps_bch_market_settings]
 bch_perps_market_id = "4000"
-bch_perps_market_skew_scale = "<%= parseEther(String(84_900)) %>"
+bch_perps_market_skew_scale = "<%= parseEther(String(147_000)) %>"
 bch_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 bch_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 bch_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/bonk.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/bonk.toml
@@ -1,6 +1,6 @@
 [var.perps_bonk_market_settings]
 bonk_perps_market_id = "1400"
-bonk_perps_market_skew_scale = "<%= parseEther(String(802_983_764_800)) %>"
+bonk_perps_market_skew_scale = "<%= parseEther(String(1_294_569_458_000)) %>"
 bonk_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 bonk_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 bonk_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/comp.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/comp.toml
@@ -1,6 +1,6 @@
 [var.perps_comp_market_settings]
 comp_perps_market_id = "4200"
-comp_perps_market_skew_scale = "<%= parseEther(String(78_300)) %>"
+comp_perps_market_skew_scale = "<%= parseEther(String(136_000)) %>"
 comp_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 comp_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 comp_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/crv.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/crv.toml
@@ -1,6 +1,6 @@
 [var.perps_crv_market_settings]
 crv_perps_market_id = "4300"
-crv_perps_market_skew_scale = "<%= parseEther(String(36_240_800)) %>"
+crv_perps_market_skew_scale = "<%= parseEther(String(68_741_000)) %>"
 crv_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 crv_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 crv_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/doge.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/doge.toml
@@ -1,6 +1,6 @@
 [var.perps_doge_market_settings]
 doge_perps_market_id = "800"
-doge_perps_market_skew_scale = "<%= parseEther(String(408_170_800)) %>"
+doge_perps_market_skew_scale = "<%= parseEther(String(885_716_000)) %>"
 doge_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 doge_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 doge_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/dot.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/dot.toml
@@ -1,6 +1,6 @@
 [var.perps_dot_market_settings]
 dot_perps_market_id = "4400"
-dot_perps_market_skew_scale = "<%= parseEther(String(7_268_400)) %>"
+dot_perps_market_skew_scale = "<%= parseEther(String(11_460_000)) %>"
 dot_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 dot_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 dot_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/ena.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/ena.toml
@@ -1,6 +1,6 @@
 [var.perps_ena_market_settings]
 ena_perps_market_id = "700"
-ena_perps_market_skew_scale = "<%= parseEther(String(39_767_500)) %>"
+ena_perps_market_skew_scale = "<%= parseEther(String(101_293_000)) %>"
 ena_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 ena_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 ena_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/fartcoin.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/fartcoin.toml
@@ -1,6 +1,6 @@
 [var.perps_fartcoin_market_settings]
 fartcoin_perps_market_id = "9900"
-fartcoin_perps_market_skew_scale = "<%= parseEther(String(8_710_600)) %>"
+fartcoin_perps_market_skew_scale = "<%= parseEther(String(30_980_000)) %>"
 fartcoin_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 fartcoin_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 fartcoin_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/fil.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/fil.toml
@@ -1,6 +1,6 @@
 [var.perps_fil_market_settings]
 fil_perps_market_id = "4900"
-fil_perps_market_skew_scale = "<%= parseEther(String(8_723_100)) %>"
+fil_perps_market_skew_scale = "<%= parseEther(String(16_007_000)) %>"
 fil_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 fil_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 fil_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/inj.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/inj.toml
@@ -1,6 +1,6 @@
 [var.perps_inj_market_settings]
 inj_perps_market_id = "2100"
-inj_perps_market_skew_scale = "<%= parseEther(String(1_128_300)) %>"
+inj_perps_market_skew_scale = "<%= parseEther(String(1_838_000)) %>"
 inj_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 inj_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 inj_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/link.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/link.toml
@@ -1,6 +1,6 @@
 [var.perps_link_market_settings]
 link_perps_market_id = "1900"
-link_perps_market_skew_scale = "<%= parseEther(String(3_054_000)) %>"
+link_perps_market_skew_scale = "<%= parseEther(String(5_770_000)) %>"
 link_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 link_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 link_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/melania.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/melania.toml
@@ -1,6 +1,6 @@
 [var.perps_melania_market_settings]
 melania_perps_market_id = "10100"
-melania_perps_market_skew_scale = "<%= parseEther(String(3_730_900)) %>"
+melania_perps_market_skew_scale = "<%= parseEther(String(5_806_000)) %>"
 melania_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 melania_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 melania_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/meme.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/meme.toml
@@ -1,6 +1,6 @@
 [var.perps_meme_market_settings]
 meme_perps_market_id = "6000"
-meme_perps_market_skew_scale = "<%= parseEther(String(1_300_000_000)) %>"
+meme_perps_market_skew_scale = "<%= parseEther(String(2_053_463_000)) %>"
 meme_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 meme_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 meme_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/mew.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/mew.toml
@@ -1,6 +1,6 @@
 [var.perps_mew_market_settings]
 mew_perps_market_id = "7500"
-mew_perps_market_skew_scale = "<%= parseEther(String(911_660_400)) %>"
+mew_perps_market_skew_scale = "<%= parseEther(String(2_062_547_000)) %>"
 mew_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 mew_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 mew_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/near.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/near.toml
@@ -1,6 +1,6 @@
 [var.perps_near_market_settings]
 near_perps_market_id = "6100"
-near_perps_market_skew_scale = "<%= parseEther(String(6_973_600)) %>"
+near_perps_market_skew_scale = "<%= parseEther(String(12_491_000)) %>"
 near_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 near_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 near_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/pepe.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/pepe.toml
@@ -1,6 +1,6 @@
 [var.perps_pepe_market_settings]
 pepe_perps_market_id = "1200"
-pepe_perps_market_skew_scale = "<%= parseEther(String(4_152_595_936_800)) %>"
+pepe_perps_market_skew_scale = "<%= parseEther(String(11_169_613_416_000)) %>"
 pepe_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 pepe_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 pepe_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/rune.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/rune.toml
@@ -1,6 +1,6 @@
 [var.perps_rune_market_settings]
 rune_perps_market_id = "1300"
-rune_perps_market_skew_scale = "<%= parseEther(String(6_000_000)) %>"
+rune_perps_market_skew_scale = "<%= parseEther(String(12_135_000)) %>"
 rune_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 rune_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 rune_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/sats.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/sats.toml
@@ -1,6 +1,6 @@
 [var.perps_sats_market_settings]
 sats_perps_market_id = "8200"
-sats_perps_market_skew_scale = "<%= parseEther(String(100_000_000_000_000)) %>"
+sats_perps_market_skew_scale = "<%= parseEther(String(158_703_939_009_000)) %>"
 sats_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 sats_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 sats_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/shib.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/shib.toml
@@ -1,6 +1,6 @@
 [var.perps_shib_market_settings]
 shib_perps_market_id = "6500"
-shib_perps_market_skew_scale = "<%= parseEther(String(2_572_944_297_100)) %>"
+shib_perps_market_skew_scale = "<%= parseEther(String(4_162_312_435_000)) %>"
 shib_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 shib_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 shib_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/snx.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/snx.toml
@@ -1,6 +1,6 @@
 [var.perps_snx_market_settings]
 snx_perps_market_id = "300"
-snx_perps_market_skew_scale = "<%= parseEther(String(3_627_800)) %>"
+snx_perps_market_skew_scale = "<%= parseEther(String(7_161_000)) %>"
 snx_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 snx_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 snx_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/strk.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/strk.toml
@@ -1,6 +1,6 @@
 [var.perps_strk_market_settings]
 strk_perps_market_id = "6600"
-strk_perps_market_skew_scale = "<%= parseEther(String(29_585_200)) %>"
+strk_perps_market_skew_scale = "<%= parseEther(String(49_609_000)) %>"
 strk_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 strk_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 strk_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/sui.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/sui.toml
@@ -1,6 +1,6 @@
 [var.perps_sui_market_settings]
 sui_perps_market_id = "2400"
-sui_perps_market_skew_scale = "<%= parseEther(String(15_109_000)) %>"
+sui_perps_market_skew_scale = "<%= parseEther(String(24_967_000)) %>"
 sui_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 sui_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 sui_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/virtual.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/virtual.toml
@@ -1,6 +1,6 @@
 [var.perps_virtual_market_settings]
 virtual_perps_market_id = "9700"
-virtual_perps_market_skew_scale = "<%= parseEther(String(4_931_300)) %>"
+virtual_perps_market_skew_scale = "<%= parseEther(String(11_285_000)) %>"
 virtual_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 virtual_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 virtual_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-mainnet-andromeda/perps/markets/wif.toml
+++ b/tomls/omnibus-base-mainnet-andromeda/perps/markets/wif.toml
@@ -1,6 +1,6 @@
 [var.perps_wif_market_settings]
 wif_perps_market_id = "500"
-wif_perps_market_skew_scale = "<%= parseEther(String(30_000_000)) %>"
+wif_perps_market_skew_scale = "<%= parseEther(String(54_873_000)) %>"
 wif_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 wif_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 wif_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/aave.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/aave.toml
@@ -1,6 +1,6 @@
 [var.perps_aave_market_settings]
 aave_perps_market_id = "3300"
-aave_perps_market_skew_scale = "<%= parseEther(String(103_900)) %>"
+aave_perps_market_skew_scale = "<%= parseEther(String(163_000)) %>"
 aave_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 aave_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 aave_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/ada.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/ada.toml
@@ -1,6 +1,6 @@
 [var.perps_ada_market_settings]
 ada_perps_market_id = "3400"
-ada_perps_market_skew_scale = "<%= parseEther(String(82_468_000)) %>"
+ada_perps_market_skew_scale = "<%= parseEther(String(221_196_000)) %>"
 ada_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 ada_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 ada_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/algo.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/algo.toml
@@ -1,6 +1,6 @@
 [var.perps_algo_market_settings]
 algo_perps_market_id = "3500"
-algo_perps_market_skew_scale = "<%= parseEther(String(54_100_700)) %>"
+algo_perps_market_skew_scale = "<%= parseEther(String(86_271_000)) %>"
 algo_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 algo_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 algo_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/axs.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/axs.toml
@@ -1,6 +1,6 @@
 [var.perps_axs_market_settings]
 axs_perps_market_id = "3800"
-axs_perps_market_skew_scale = "<%= parseEther(String(2_218_700)) %>"
+axs_perps_market_skew_scale = "<%= parseEther(String(3_341_000)) %>"
 axs_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 axs_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 axs_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/bch.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/bch.toml
@@ -1,6 +1,6 @@
 [var.perps_bch_market_settings]
 bch_perps_market_id = "4000"
-bch_perps_market_skew_scale = "<%= parseEther(String(84_900)) %>"
+bch_perps_market_skew_scale = "<%= parseEther(String(147_000)) %>"
 bch_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 bch_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 bch_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/bonk.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/bonk.toml
@@ -1,6 +1,6 @@
 [var.perps_bonk_market_settings]
 bonk_perps_market_id = "1400"
-bonk_perps_market_skew_scale = "<%= parseEther(String(802_983_764_800)) %>"
+bonk_perps_market_skew_scale = "<%= parseEther(String(1_294_569_458_000)) %>"
 bonk_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 bonk_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 bonk_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/btc.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/btc.toml
@@ -30,7 +30,7 @@ func = "updatePriceData"
 args = [
     "<%= settings.btc_perps_market_id %>",
     "<%= extras.btc_oracle_id %>",
-    "<%= settings.strict_staleness_tolerance %>",
+    "<%= settings.default_staleness_tolerance %>",
 ]
 
 [invoke.addPerpsBtcSettlementStrategy]

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/comp.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/comp.toml
@@ -1,6 +1,6 @@
 [var.perps_comp_market_settings]
 comp_perps_market_id = "4200"
-comp_perps_market_skew_scale = "<%= parseEther(String(78_300)) %>"
+comp_perps_market_skew_scale = "<%= parseEther(String(136_000)) %>"
 comp_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 comp_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 comp_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/crv.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/crv.toml
@@ -1,6 +1,6 @@
 [var.perps_crv_market_settings]
 crv_perps_market_id = "4300"
-crv_perps_market_skew_scale = "<%= parseEther(String(36_240_800)) %>"
+crv_perps_market_skew_scale = "<%= parseEther(String(68_741_000)) %>"
 crv_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 crv_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 crv_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/doge.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/doge.toml
@@ -1,6 +1,6 @@
 [var.perps_doge_market_settings]
 doge_perps_market_id = "800"
-doge_perps_market_skew_scale = "<%= parseEther(String(408_170_800)) %>"
+doge_perps_market_skew_scale = "<%= parseEther(String(885_716_000)) %>"
 doge_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 doge_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 doge_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/dot.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/dot.toml
@@ -1,6 +1,6 @@
 [var.perps_dot_market_settings]
 dot_perps_market_id = "4400"
-dot_perps_market_skew_scale = "<%= parseEther(String(7_268_400)) %>"
+dot_perps_market_skew_scale = "<%= parseEther(String(11_460_000)) %>"
 dot_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 dot_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 dot_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/ena.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/ena.toml
@@ -1,6 +1,6 @@
 [var.perps_ena_market_settings]
 ena_perps_market_id = "700"
-ena_perps_market_skew_scale = "<%= parseEther(String(39_767_500)) %>"
+ena_perps_market_skew_scale = "<%= parseEther(String(101_293_000)) %>"
 ena_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 ena_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 ena_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/eth.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/eth.toml
@@ -30,7 +30,7 @@ func = "updatePriceData"
 args = [
     "<%= settings.eth_perps_market_id %>",
     "<%= extras.eth_oracle_id %>",
-    "<%= settings.strict_staleness_tolerance %>",
+    "<%= settings.default_staleness_tolerance %>",
 ]
 
 [invoke.addPerpsEthSettlementStrategy]

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/fartcoin.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/fartcoin.toml
@@ -1,6 +1,6 @@
 [var.perps_fartcoin_market_settings]
 fartcoin_perps_market_id = "9900"
-fartcoin_perps_market_skew_scale = "<%= parseEther(String(8_710_600)) %>"
+fartcoin_perps_market_skew_scale = "<%= parseEther(String(30_980_000)) %>"
 fartcoin_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 fartcoin_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 fartcoin_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/fil.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/fil.toml
@@ -1,6 +1,6 @@
 [var.perps_fil_market_settings]
 fil_perps_market_id = "4900"
-fil_perps_market_skew_scale = "<%= parseEther(String(8_723_100)) %>"
+fil_perps_market_skew_scale = "<%= parseEther(String(16_007_000)) %>"
 fil_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 fil_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 fil_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/inj.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/inj.toml
@@ -1,6 +1,6 @@
 [var.perps_inj_market_settings]
 inj_perps_market_id = "2100"
-inj_perps_market_skew_scale = "<%= parseEther(String(1_128_300)) %>"
+inj_perps_market_skew_scale = "<%= parseEther(String(1_838_000)) %>"
 inj_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 inj_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 inj_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/link.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/link.toml
@@ -1,6 +1,6 @@
 [var.perps_link_market_settings]
 link_perps_market_id = "1900"
-link_perps_market_skew_scale = "<%= parseEther(String(3_054_000)) %>"
+link_perps_market_skew_scale = "<%= parseEther(String(5_770_000)) %>"
 link_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 link_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 link_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/melania.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/melania.toml
@@ -1,6 +1,6 @@
 [var.perps_melania_market_settings]
 melania_perps_market_id = "10100"
-melania_perps_market_skew_scale = "<%= parseEther(String(3_730_900)) %>"
+melania_perps_market_skew_scale = "<%= parseEther(String(5_806_000)) %>"
 melania_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 melania_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 melania_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/meme.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/meme.toml
@@ -1,6 +1,6 @@
 [var.perps_meme_market_settings]
 meme_perps_market_id = "6000"
-meme_perps_market_skew_scale = "<%= parseEther(String(1_300_000_000)) %>"
+meme_perps_market_skew_scale = "<%= parseEther(String(2_053_463_000)) %>"
 meme_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 meme_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 meme_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/mew.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/mew.toml
@@ -1,6 +1,6 @@
 [var.perps_mew_market_settings]
 mew_perps_market_id = "7500"
-mew_perps_market_skew_scale = "<%= parseEther(String(911_660_400)) %>"
+mew_perps_market_skew_scale = "<%= parseEther(String(2_062_547_000)) %>"
 mew_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 mew_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 mew_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/near.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/near.toml
@@ -1,6 +1,6 @@
 [var.perps_near_market_settings]
 near_perps_market_id = "6100"
-near_perps_market_skew_scale = "<%= parseEther(String(6_973_600)) %>"
+near_perps_market_skew_scale = "<%= parseEther(String(12_491_000)) %>"
 near_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 near_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 near_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/pepe.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/pepe.toml
@@ -1,6 +1,6 @@
 [var.perps_pepe_market_settings]
 pepe_perps_market_id = "1200"
-pepe_perps_market_skew_scale = "<%= parseEther(String(4_152_595_936_800)) %>"
+pepe_perps_market_skew_scale = "<%= parseEther(String(11_169_613_416_000)) %>"
 pepe_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 pepe_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 pepe_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/rune.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/rune.toml
@@ -1,6 +1,6 @@
 [var.perps_rune_market_settings]
 rune_perps_market_id = "1300"
-rune_perps_market_skew_scale = "<%= parseEther(String(6_000_000)) %>"
+rune_perps_market_skew_scale = "<%= parseEther(String(12_135_000)) %>"
 rune_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 rune_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 rune_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/sats.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/sats.toml
@@ -1,6 +1,6 @@
 [var.perps_sats_market_settings]
 sats_perps_market_id = "8200"
-sats_perps_market_skew_scale = "<%= parseEther(String(100_000_000_000_000)) %>"
+sats_perps_market_skew_scale = "<%= parseEther(String(158_703_939_009_000)) %>"
 sats_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 sats_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 sats_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/shib.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/shib.toml
@@ -1,6 +1,6 @@
 [var.perps_shib_market_settings]
 shib_perps_market_id = "6500"
-shib_perps_market_skew_scale = "<%= parseEther(String(2_572_944_297_100)) %>"
+shib_perps_market_skew_scale = "<%= parseEther(String(4_162_312_435_000)) %>"
 shib_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 shib_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 shib_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/snx.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/snx.toml
@@ -1,6 +1,6 @@
 [var.perps_snx_market_settings]
 snx_perps_market_id = "300"
-snx_perps_market_skew_scale = "<%= parseEther(String(3_627_800)) %>"
+snx_perps_market_skew_scale = "<%= parseEther(String(7_161_000)) %>"
 snx_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 snx_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 snx_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"
@@ -21,7 +21,7 @@ snx_perps_endorsed_liquidator = "0x11233749514Ab8d00C0A5873DF7428b3db70030f"
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "createMarket"
-args = ["<%= settings.snx_perps_market_id %>", "Synthetix", "SNX"]
+args = ["<%= settings.snx_perps_market_id %>", "Synthetix Network Token", "SNX"]
 
 [invoke.setPerpsPriceSnx]
 target = ["perpsFactory.PerpsMarketProxy"]

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/snx.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/snx.toml
@@ -21,7 +21,7 @@ snx_perps_endorsed_liquidator = "0x11233749514Ab8d00C0A5873DF7428b3db70030f"
 target = ["perpsFactory.PerpsMarketProxy"]
 fromCall.func = "owner"
 func = "createMarket"
-args = ["<%= settings.snx_perps_market_id %>", "Synthetix Network Token", "SNX"]
+args = ["<%= settings.snx_perps_market_id %>", "Synthetix", "SNX"]
 
 [invoke.setPerpsPriceSnx]
 target = ["perpsFactory.PerpsMarketProxy"]

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/strk.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/strk.toml
@@ -1,6 +1,6 @@
 [var.perps_strk_market_settings]
 strk_perps_market_id = "6600"
-strk_perps_market_skew_scale = "<%= parseEther(String(29_585_200)) %>"
+strk_perps_market_skew_scale = "<%= parseEther(String(49_609_000)) %>"
 strk_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 strk_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 strk_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/sui.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/sui.toml
@@ -1,6 +1,6 @@
 [var.perps_sui_market_settings]
 sui_perps_market_id = "2400"
-sui_perps_market_skew_scale = "<%= parseEther(String(15_109_000)) %>"
+sui_perps_market_skew_scale = "<%= parseEther(String(24_967_000)) %>"
 sui_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 sui_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 sui_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/virtual.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/virtual.toml
@@ -1,6 +1,6 @@
 [var.perps_virtual_market_settings]
 virtual_perps_market_id = "9700"
-virtual_perps_market_skew_scale = "<%= parseEther(String(4_931_300)) %>"
+virtual_perps_market_skew_scale = "<%= parseEther(String(11_285_000)) %>"
 virtual_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 virtual_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 virtual_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"

--- a/tomls/omnibus-base-sepolia-andromeda/perps/markets/wif.toml
+++ b/tomls/omnibus-base-sepolia-andromeda/perps/markets/wif.toml
@@ -1,6 +1,6 @@
 [var.perps_wif_market_settings]
 wif_perps_market_id = "500"
-wif_perps_market_skew_scale = "<%= parseEther(String(30_000_000)) %>"
+wif_perps_market_skew_scale = "<%= parseEther(String(54_873_000)) %>"
 wif_perps_market_max_funding_velocity = "<%= parseEther('36') %>"
 wif_perps_maker_fee_ratio = "<%= parseEther('0.000200') %>"
 wif_perps_taker_fee_ratio = "<%= parseEther('0.001000') %>"


### PR DESCRIPTION
In addition to sccp 392, updates the staleness tolernace to default on eth and btc on sepolia in order to test withdrawals (for a future sccp)