### PR TITLE
aux reset timestamp update

### DIFF
--- a/omnibus-mainnet.toml
+++ b/omnibus-mainnet.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "21"
+version = "22"
 description = "Includes the full synthetix system with configurations applied"
 deployers = [
     "0x1C8236B406911A376369e33D39189F1b4B39F27D",
@@ -128,7 +128,7 @@ defaultValue = "0xFa1DF09D8d09D6E8FAB2a6C4712fEa02ce203e99"
 defaultValue = "<%= parseEther('0.1') %>"
 
 [setting.treasury_aux_reset_time]
-defaultValue = "<%= 365 * 24 * 60 * 60  %>"
+defaultValue = "<%= 1423453  %>"
 
 [setting.pool_owner]
 defaultValue = "0x302d2451d9f47620374B54c521423Bf0403916A2"

--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "11"
+version = "12"
 description = "Includes the full synthetix system with configurations applied"
 deployers = [
     "0x1C8236B406911A376369e33D39189F1b4B39F27D",
@@ -113,7 +113,7 @@ defaultValue = "0xFa1DF09D8d09D6E8FAB2a6C4712fEa02ce203e99"
 defaultValue = "<%= parseEther('0.1') %>"
 
 [setting.treasury_aux_reset_time]
-defaultValue = "<%= 365 * 24 * 60 * 60  %>"
+defaultValue = "<%= 1423685  %>"
 
 [setting.pool_owner]
 defaultValue = "0x302d2451d9f47620374B54c521423Bf0403916A2"


### PR DESCRIPTION
- The [ethereum transaction](https://etherscan.io/tx/0x0796f8ce8ecc34ba590267ea8a1743d95f36b63bef6b509818c8783ae04bfff2) which initiated the treasury market timer bears a timestamp of 1745670887
- The [optimism transaction](https://optimistic.etherscan.io/tx/0x27fa00536565f9ee70db42985c2cfad65a2217d37ba900d9db40e48482bec61e) which initiated the treasury market timer bears a timestamp of 1745670655

The reset time 12 May 2025, 23:59 UTC corresponds to the unix timestamp of 1747094340

Accordingly, treasury_aux_reset_time should be set to:
- ethereum: 1747094340 - 1745670887 =1423453
- optimism 1747094340 - 1745670655 = 1423685