### PR TITLE
update eos price feed to snx feed

### DIFF
--- a/omnibus-base-mainnet-andromeda.toml
+++ b/omnibus-base-mainnet-andromeda.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "92"
+version = "93"
 description = "Andromeda deployment"
 preset = "andromeda"
 deployers = [
@@ -431,7 +431,7 @@ pyth_feed_id_dot = "0xca3eed9b267293f6595901c734c7525ce8ef49adafe8284606ceb307af
 pyth_feed_id_dydx = "0x6489800bb8974169adfe35937bf6736507097d13c190d760c557108c7e93a81b"
 pyth_feed_id_eigen = "0xc65db025687356496e8653d0d6608eec64ce2d96e2e28c530e574f0e4f712380"
 pyth_feed_id_ena = "0xb7910ba7322db020416fcac28b48c01212fd9cc8fbcbaf7d30477ed8605f6bd4"
-pyth_feed_id_eos = "0x06ade621dbc31ed0fc9255caaab984a468abe84164fb2ccc76f02a4636d97e31"
+pyth_feed_id_eos = "0x39d020f60982ed892abbcd4a06a276a9f9b7bfbce003204c110b6e488f502da3" #temporarily set to snx price feed / should be switched to `A` once available
 pyth_feed_id_etc = "0x7f5cc8d963fc5b3d2ae41fe5685ada89fd4f14b435f8050f28c7fd409f40c2d8"
 pyth_feed_id_eth = "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
 pyth_feed_id_ethbtc = "0xc96458d393fe9deb7a7d63a0ac41e2898a67a7750dbd166673279e06c868df0a"

--- a/omnibus-base-sepolia-andromeda.toml
+++ b/omnibus-base-sepolia-andromeda.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "91"
+version = "92"
 description = "Andromeda dev deployment"
 preset = "andromeda"
 deployers = ["0x48914229deDd5A9922f44441ffCCfC2Cb7856Ee9"]
@@ -468,7 +468,7 @@ pyth_feed_id_dot = "0xca3eed9b267293f6595901c734c7525ce8ef49adafe8284606ceb307af
 pyth_feed_id_dydx = "0x6489800bb8974169adfe35937bf6736507097d13c190d760c557108c7e93a81b"
 pyth_feed_id_eigen = "0xc65db025687356496e8653d0d6608eec64ce2d96e2e28c530e574f0e4f712380"
 pyth_feed_id_ena = "0xb7910ba7322db020416fcac28b48c01212fd9cc8fbcbaf7d30477ed8605f6bd4"
-pyth_feed_id_eos = "0x06ade621dbc31ed0fc9255caaab984a468abe84164fb2ccc76f02a4636d97e31"
+pyth_feed_id_eos = "0x39d020f60982ed892abbcd4a06a276a9f9b7bfbce003204c110b6e488f502da3" #temporarily set to snx price feed / should be switched to `A` once available
 pyth_feed_id_etc = "0x7f5cc8d963fc5b3d2ae41fe5685ada89fd4f14b435f8050f28c7fd409f40c2d8"
 pyth_feed_id_eth = "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
 pyth_feed_id_ethbtc = "0xc96458d393fe9deb7a7d63a0ac41e2898a67a7750dbd166673279e06c868df0a"


### PR DESCRIPTION
hey @noisekit i've updated the price feed of eos here to the snx  price feed. This is fine, because there are no positions and the caps are set to zero. https://exchange.synthetix.io/market/?asset=EOS&provider=snx_v3_base Once we have an `A` feed we'll switch it, but we need to send this transaction before the 25th in order to avoid having stale feeds... Since pyth is deprecating their EOS feed.