### PR TITLE
synthetix-v3 deprecation step 2: sweep all collaterals

### DIFF
--- a/omnibus-mainnet.toml
+++ b/omnibus-mainnet.toml
@@ -38,6 +38,7 @@ include = [
 
     # Full protocol deprecation
     "tomls/omnibus-mainnet/full-deprecation.toml",
+    "tomls/omnibus-mainnet/deprecate-collaterals.toml",
 ]
 
 [setting.snx_package]

--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -36,6 +36,7 @@ include = [
 
     # Full protocol deprecation
     "tomls/omnibus-optimism-mainnet/full-deprecation.toml",
+    "tomls/omnibus-optimism-mainnet/deprecate-collaterals.toml",
 ]
 
 [setting.snx_package]

--- a/tomls/omnibus-mainnet/deprecate-collaterals.toml
+++ b/tomls/omnibus-mainnet/deprecate-collaterals.toml
@@ -1,0 +1,28 @@
+# Step 2 of 2-step protocol deprecation: sweep every configured
+# collateral on CoreProxy to the deprecation receiver. Step 1
+# (synthetix-v3-deprecation) disabled all user-facing entry points;
+# this PR moves the funds out.
+#
+# CollateralConfigurationModule.deprecateCollateral is owner-only,
+# transfers the entire CoreProxy balance of the token to the receiver,
+# and sets depositingEnabled = false on the collateral config.
+#
+# Configured collaterals on Ethereum CoreProxy: SNX and snxUSD.
+
+[setting.deprecation_receiver]
+defaultValue = "0xEb3107117FEAd7de89Cd14D463D340A2E6917769"
+
+[invoke.deprecateCollateralSnx]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "deprecateCollateral"
+args = ["<%= settings.snx_address %>", "<%= settings.deprecation_receiver %>"]
+
+[invoke.deprecateCollateralSnxUsd]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "deprecateCollateral"
+args = [
+    "<%= imports.system.contracts.USDProxy.address %>",
+    "<%= settings.deprecation_receiver %>",
+]

--- a/tomls/omnibus-optimism-mainnet/deprecate-collaterals.toml
+++ b/tomls/omnibus-optimism-mainnet/deprecate-collaterals.toml
@@ -1,0 +1,27 @@
+# Step 2 of 2-step protocol deprecation: sweep every configured
+# collateral on CoreProxy to the pdao receiver. Step 1
+# (synthetix-v3-deprecation) disabled all user-facing entry points;
+# this PR moves the funds out.
+#
+# Configured collaterals on Optimism CoreProxy: SNX, WETH, snxUSD.
+
+[invoke.deprecateCollateralSnx]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "deprecateCollateral"
+args = ["<%= settings.snx_address %>", "<%= settings.pdao %>"]
+
+[invoke.deprecateCollateralWeth]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "deprecateCollateral"
+args = ["<%= settings.weth_address %>", "<%= settings.pdao %>"]
+
+[invoke.deprecateCollateralSnxUsd]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "deprecateCollateral"
+args = [
+    "<%= imports.system.contracts.USDProxy.address %>",
+    "<%= settings.pdao %>",
+]


### PR DESCRIPTION
## Summary

Step 2 of the two-step protocol deprecation. Stacks on top of #722 (which disables every user-facing entry point). This PR is the funds-moving step.

- Adds `tomls/{omnibus-mainnet,omnibus-optimism-mainnet}/deprecate-collaterals.toml` and includes them from each omnibus.
- Calls `CoreProxy.deprecateCollateral(token, receiver)` for every configured collateral on each chain, which (a) transfers the entire CoreProxy balance of `token` to `receiver`, and (b) sets `depositingEnabled = false` on the collateral config.

| Chain | Collaterals swept | Receiver |
|---|---|---|
| Ethereum mainnet (1) | SNX `0xC011…a6f`, snxUSD `0xb2F3…8175` | `setting.deprecation_receiver` = `0xEb3107117FEAd7de89Cd14D463D340A2E6917769` |
| Optimism (10) | SNX `0x8700…99B4`, WETH `0x4200…0006`, snxUSD `0xb2F3…8175` | `setting.pdao` = `0x6cd3f878852769e04A723A5f66CA7DD4d9E38A6C` |

The optimism receiver matches phase2-drawdown's pre-existing `[invoke.deprecate]`, which #722 removed so the sweep would land in this PR instead.

## Deployment plan

1. **Merge & deploy #722 first.** Lock down user-facing entry points; wait the chosen window.
2. Merge this PR. Run `yarn cannon build` for both omnibuses (mainnet `--chain-id 1`, optimism `--chain-id 10`). Each chain's CoreProxy ends with zero balance of every previously-configured collateral, and the receiver address has the swept balance.

## Test plan

- [ ] Forked dry-run on Ethereum mainnet ends with: CoreProxy balance of SNX = 0 and snxUSD = 0; receiver gains the swept amounts (~132,591,430 SNX + ~5,011 snxUSD on the current fork).
- [ ] Forked dry-run on Optimism ends with: CoreProxy balance of SNX, WETH, snxUSD all = 0; pdao gains the swept amounts (~20,192,514 SNX + ~0.02 WETH + ~93.35 snxUSD on the current fork).
- [ ] Both `getCollateralConfiguration(token).depositingEnabled` checks return `false` post-build (already false post-step-1 effectively, but this re-asserts).
- [ ] Re-run dry-runs without `--upgrade-from`: cannon reports no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)