### PR TITLE
synthetix-v3 deprecation step 1: disable all user-facing entry points

### DIFF
--- a/omnibus-mainnet.toml
+++ b/omnibus-mainnet.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "26"
+version = "27"
 description = "Includes the full synthetix system with configurations applied"
 deployers = [
     "0x1C8236B406911A376369e33D39189F1b4B39F27D",
@@ -35,10 +35,13 @@ include = [
     "tomls/omnibus-mainnet/pools/treasury.toml",
     "tomls/omnibus-mainnet/treasury-market.toml",
     "tomls/omnibus-mainnet/liquidation-permissions.toml",
+
+    # Full protocol deprecation
+    "tomls/omnibus-mainnet/full-deprecation.toml",
 ]
 
 [setting.snx_package]
-defaultValue = "synthetix:3.12.0"
+defaultValue = "synthetix:3.14.1"
 
 [setting.v2x_package]
 defaultValue = "synthetix:2.101.2"
@@ -56,7 +59,7 @@ defaultValue = "synthetix-perps-market:3.3.19"
 defaultValue = "synthetix-legacy-market:3.12.1"
 
 [setting.treasury_market_package]
-defaultValue = "synthetix-treasury-market:3.12.3"
+defaultValue = "synthetix-treasury-market:3.14.2"
 
 [setting.susde_package]
 defaultValue = 'susde-token'
@@ -162,6 +165,12 @@ defaultValue = "0x100c6c18381c9a7527762063047236356bbd0b8d"
 [setting.pool420_migrate_address]
 defaultValue = "0x8bfd24F68149E3d4e9635a6E26b0e43EEfd2C692"
 
+[setting.aggregator_issued_synths_address]
+defaultValue = "0xA1C62734a81e2C42357781322Aa4D430C0a50A08"
+
+[setting.aggregator_debt_ratio_address]
+defaultValue = "0x2305f5f9EF3aBF0d6d02411ACa44F85113b247Af"
+
 # we want to enable the spot market wrapper for usde
 [import.usde]
 source = "usde-token"
@@ -228,3 +237,48 @@ governance_initial_epoch_end_date = "1726504075"
 [var.treasuryInfo]
 treasury_account_id = "10"
 treasury_liquidator_address = "0x9DAffb42b60Bb14d8EE80b503AAfC312dCbAF552"
+
+
+#depends = ['provision.legacyMarket']
+
+[invoke.disableCoreDeposit]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('deposit') %>", false]
+
+#depends = ['provision.system']
+
+[invoke.disableCoreDelegate]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('delegateCollateral') %>", false]
+
+[invoke.setMainnetOnlyDebt]
+target = ["legacyMarket.v2x.AddressResolver"]
+func = "importAddresses"
+fromCall.func = "owner"
+args = [
+    [
+        "<%= formatBytes32String('ext:AggregatorIssuedSynths') %>",
+        "<%= formatBytes32String('ext:AggregatorDebtRatio') %>",
+    ],
+    [
+        "<%= settings.aggregator_issued_synths_address %>",
+        "<%= settings.aggregator_debt_ratio_address %>",
+    ],
+]
+
+depends = [
+    'provision.legacyMarket',
+    'setting.aggregator_issued_synths_address',
+    'setting.aggregator_debt_ratio_address',
+]
+
+[invoke.refreshResolverCache]
+target = ["legacyMarket.v2x.Issuer", "legacyMarket.v2x.FeePool"]
+func = "rebuildCache"
+fromCall.func = "owner"
+
+depends = ["invoke.setMainnetOnlyDebt"]

--- a/omnibus-mainnet.toml
+++ b/omnibus-mainnet.toml
@@ -165,12 +165,6 @@ defaultValue = "0x100c6c18381c9a7527762063047236356bbd0b8d"
 [setting.pool420_migrate_address]
 defaultValue = "0x8bfd24F68149E3d4e9635a6E26b0e43EEfd2C692"
 
-[setting.aggregator_issued_synths_address]
-defaultValue = "0xA1C62734a81e2C42357781322Aa4D430C0a50A08"
-
-[setting.aggregator_debt_ratio_address]
-defaultValue = "0x2305f5f9EF3aBF0d6d02411ACa44F85113b247Af"
-
 # we want to enable the spot market wrapper for usde
 [import.usde]
 source = "usde-token"
@@ -254,31 +248,3 @@ target = ["system.CoreProxy"]
 fromCall.func = "owner"
 func = "setFeatureFlagAllowAll"
 args = ["<%= formatBytes32String('delegateCollateral') %>", false]
-
-[invoke.setMainnetOnlyDebt]
-target = ["legacyMarket.v2x.AddressResolver"]
-func = "importAddresses"
-fromCall.func = "owner"
-args = [
-    [
-        "<%= formatBytes32String('ext:AggregatorIssuedSynths') %>",
-        "<%= formatBytes32String('ext:AggregatorDebtRatio') %>",
-    ],
-    [
-        "<%= settings.aggregator_issued_synths_address %>",
-        "<%= settings.aggregator_debt_ratio_address %>",
-    ],
-]
-
-depends = [
-    'provision.legacyMarket',
-    'setting.aggregator_issued_synths_address',
-    'setting.aggregator_debt_ratio_address',
-]
-
-[invoke.refreshResolverCache]
-target = ["legacyMarket.v2x.Issuer", "legacyMarket.v2x.FeePool"]
-func = "rebuildCache"
-fromCall.func = "owner"
-
-depends = ["invoke.setMainnetOnlyDebt"]

--- a/omnibus-optimism-mainnet.toml
+++ b/omnibus-optimism-mainnet.toml
@@ -1,5 +1,5 @@
 name = "synthetix-omnibus"
-version = "16"
+version = "17"
 description = "Includes the full synthetix system with configurations applied"
 deployers = [
     "0x1C8236B406911A376369e33D39189F1b4B39F27D",
@@ -33,10 +33,13 @@ include = [
     "tomls/omnibus-optimism-mainnet/treasury-market.toml",
 
     "tomls/omnibus-optimism-mainnet/liquidation-permissions.toml",
+
+    # Full protocol deprecation
+    "tomls/omnibus-optimism-mainnet/full-deprecation.toml",
 ]
 
 [setting.snx_package]
-defaultValue = "synthetix:3.12.0"
+defaultValue = "synthetix:3.13.0"
 
 [setting.v2x_package]
 defaultValue = "synthetix:2.101.2"
@@ -192,7 +195,7 @@ governance_initial_epoch_end_date = "1726504075"
 target = ["legacyMarket.Proxy"]
 fromCall.func = "owner"
 func = "setPauseMigration"
-args = [false]
+args = [true]
 
 [invoke.disableLiquidate]
 target = ["system.CoreProxy"]
@@ -221,3 +224,29 @@ args = ["1", "31536000", "<%= parseEther('1') %>", "<%= parseEther('0.5') %>"]
 [var.treasuryInfo]
 treasury_account_id = "10"
 treasury_liquidator_address = "0x9DAffb42b60Bb14d8EE80b503AAfC312dCbAF552"
+
+# deprecation
+
+[invoke.setPausedStablecoinConversion]
+target = ["legacyMarket.Proxy"]
+fromCall.func = "owner"
+func = "setPauseStablecoinConversion"
+args = ['true']
+
+[invoke.disableCoreDeposit]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('deposit') %>", false]
+
+[invoke.disableCoreDelegate]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('delegateCollateral') %>", false]
+
+[invoke.disableMintMarket]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('withdrawMarketUsd') %>", false]

--- a/tomls/omnibus-mainnet/full-deprecation.toml
+++ b/tomls/omnibus-mainnet/full-deprecation.toml
@@ -1,0 +1,84 @@
+# Step 1 of 2-step protocol deprecation: lock down every user-callable
+# feature on CoreProxy and pause LegacyMarket stablecoin conversion.
+# A separate follow-up PR adds the deprecateCollateral sweeps that move
+# CoreProxy's collateral balances to the deprecation receiver.
+#
+# Existing invokes already cover:
+#   - deposit, delegateCollateral, liquidate, liquidateVault (CoreProxy)
+#   - LegacyMarket setPauseMigration(true)
+
+# ---- CoreProxy feature flag disables ----
+
+[invoke.disableWithdraw]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('withdraw') %>", false]
+
+[invoke.disableMintUsd]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('mintUsd') %>", false]
+
+[invoke.disableBurnUsd]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('burnUsd') %>", false]
+
+[invoke.disableMigrateDelegation]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('migrateDelegation') %>", false]
+
+[invoke.disableCreateAccount]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('createAccount') %>", false]
+
+[invoke.disableClaimRewards]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('claimRewards') %>", false]
+
+[invoke.disableTransferCrossChain]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('transferCrossChain') %>", false]
+
+[invoke.disableDepositMarketUsd]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('depositMarketUsd') %>", false]
+
+[invoke.disableWithdrawMarketUsd]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('withdrawMarketUsd') %>", false]
+
+[invoke.disableDepositMarketCollateral]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('depositMarketCollateral') %>", false]
+
+[invoke.disableWithdrawMarketCollateral]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('withdrawMarketCollateral') %>", false]
+
+# ---- LegacyMarket pauses (pauseMigration is set elsewhere) ----
+
+[invoke.pauseLMStablecoinConversion]
+target = ["legacyMarket.Proxy"]
+fromCall.func = "owner"
+func = "setPauseStablecoinConversion"
+args = [true]

--- a/tomls/omnibus-optimism-mainnet/full-deprecation.toml
+++ b/tomls/omnibus-optimism-mainnet/full-deprecation.toml
@@ -1,0 +1,69 @@
+# Step 1 of 2-step protocol deprecation: lock down every remaining
+# user-callable feature on CoreProxy. A separate follow-up PR adds the
+# deprecateCollateral sweeps for SNX, WETH, and snxUSD.
+#
+# The omnibus already covers (also part of this step):
+#   - deposit, delegateCollateral, withdrawMarketUsd, liquidate,
+#     liquidateVault (CoreProxy)
+#   - LegacyMarket setPauseStablecoinConversion(true)
+#   - LegacyMarket setPauseMigration(true)
+
+[invoke.disableWithdraw]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('withdraw') %>", false]
+
+[invoke.disableMintUsd]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('mintUsd') %>", false]
+
+[invoke.disableBurnUsd]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('burnUsd') %>", false]
+
+[invoke.disableMigrateDelegation]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('migrateDelegation') %>", false]
+
+[invoke.disableCreateAccount]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('createAccount') %>", false]
+
+[invoke.disableClaimRewards]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('claimRewards') %>", false]
+
+[invoke.disableTransferCrossChain]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('transferCrossChain') %>", false]
+
+[invoke.disableDepositMarketUsd]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('depositMarketUsd') %>", false]
+
+[invoke.disableDepositMarketCollateral]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('depositMarketCollateral') %>", false]
+
+[invoke.disableWithdrawMarketCollateral]
+target = ["system.CoreProxy"]
+fromCall.func = "owner"
+func = "setFeatureFlagAllowAll"
+args = ["<%= formatBytes32String('withdrawMarketCollateral') %>", false]


### PR DESCRIPTION
## Summary

Step 1 of a two-step protocol deprecation. **Disables only** — no funds move on this PR. The follow-up PR (#727) sweeps every configured collateral via `deprecateCollateral` to the per-chain receiver. Replaces #722 with a clean diff against `main`.

### What this PR does

**Mainnet (`omnibus-mainnet.toml`)**
- Bumps omnibus `version = "26"` → `"27"`
- Bumps `synthetix:3.12.0` → `synthetix:3.14.1` and `synthetix-treasury-market:3.12.3` → `3.14.2`. The `synthetix` bump is **required**: `CollateralConfigurationModule.deprecateCollateral(address,address)` was introduced in [#2377](https://github.com/Synthetixio/synthetix-v3/pull/2377) (between tags `v3.12.3` and `v3.13.0`). The currently deployed CoreProxy at `0xffffffaEff0B96Ea8e4f94b2253f31abdD875847` returns `UnknownSelector(0x8bcd3621)` for that selector — confirmed against live mainnet. The bump is what makes the step-2 sweep possible.
- New invokes: `disableCoreDeposit`, `disableCoreDelegate`
- Includes `tomls/omnibus-mainnet/full-deprecation.toml`

**Optimism (`omnibus-optimism-mainnet.toml`)**
- Bumps omnibus `version = "16"` → `"17"`, `synthetix:3.12.0` → `3.13.0` (same reason — `v3.13.0` is the first tag containing `deprecateCollateral`)
- Fixes pre-existing bug: `pauseLMMigration` was passing `args = [false]` (un-pausing migration on every build). Now `[true]`.
- Adds `setPausedStablecoinConversion` targeting `legacyMarket.Proxy` (the user-facing proxy), not `legacyMarket.Market` (which is the router impl — writes to its storage don't affect what the proxy reads)
- New invokes: `disableCoreDeposit`, `disableCoreDelegate`, `disableMintMarket` (= disable `withdrawMarketUsd`)
- Includes `tomls/omnibus-optimism-mainnet/full-deprecation.toml`

**Both chains — `full-deprecation.toml`**
Disables every remaining user-callable feature flag on CoreProxy via `setFeatureFlagAllowAll(<flag>, false)`:
`withdraw`, `mintUsd`, `burnUsd`, `migrateDelegation`, `createAccount`, `claimRewards`, `transferCrossChain`, `depositMarketUsd`, `withdrawMarketUsd`, `depositMarketCollateral`, `withdrawMarketCollateral`.
Mainnet additionally pauses `LegacyMarket.setPauseStablecoinConversion(true)`.

### Verification on forked dry-runs (both chains)

Verified end-to-end on `--keep-alive --impersonate-all` dry-runs:

| | Mainnet (`--chain-id 1`) | Optimism (`--chain-id 10`) |
|---|---|---|
| Build result | ✅ `synthetix-omnibus:27@main` (~631k gas) | ✅ `synthetix-omnibus:17@main` (~28.2M gas) |
| CoreProxy gated functions | ✅ 16/16 revert with `FeatureUnavailable("<flag>")` matching the expected flag | ✅ 16/16 revert with `FeatureUnavailable("<flag>")` matching the expected flag |
| LegacyMarket `convertUSD(uint256)` | ✅ `Paused()` (`0x9e87fac8`) | ✅ `Paused()` |
| LegacyMarket `migrate(uint128)` | ✅ `Paused()` | ✅ `Paused()` |
| Collateral balances on CoreProxy (sweep is step 2) | SNX `132,591,430.61` · snxUSD `5,010.91` (unchanged) | SNX `20,191,682.03` · WETH `0.02` · snxUSD `93.35` (unchanged) |

### Deployment plan

1. Merge this PR. Run `yarn cannon build` for both omnibuses; users can no longer deposit / delegate / mint / burn / migrate / withdraw / claim / liquidate / transfer-cross-chain.
2. Wait for the chosen announcement / soak window.
3. Merge follow-up PR #727. That deploy executes the `deprecateCollateral` sweeps for every collateral on each chain.

### Test plan

- [x] Mainnet dry-run builds green and produces `synthetix-omnibus:27@main`
- [x] Optimism dry-run builds green and produces `synthetix-omnibus:17@main`
- [x] On each forked end state, every surveyed feature flag `getFeatureFlagAllowAll(...) == false`; each gated user function reverts with `FeatureUnavailable("<flag>")`; `LegacyMarket.pauseStablecoinConversion()` and `pauseMigration()` both `true`; CoreProxy collateral balances unchanged
- [ ] Re-run dry-runs without `--upgrade-from`: cannon should report no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)